### PR TITLE
Check the correct logging level in iterpolated string handlers

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,9 +23,15 @@
 
   <!-- Development dependencies -->
   <ItemGroup>
+    <PackageVersion Include="coverlet.collector" Version="3.2.0" />
+    <PackageVersion Include="FluentAssertions" Version="6.10.0" />
+    <PackageVersion Include="FluentAssertions.Analyzers" Version="0.17.2" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
+    <PackageVersion Include="xunit" Version="2.4.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />
   </ItemGroup>
 
 </Project>

--- a/Louis.sln
+++ b/Louis.sln
@@ -43,6 +43,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "- Dependencies", "- Depende
 		global.json = global.json
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LoggingTests", "tests\LoggingTests\LoggingTests.csproj", "{F6604E25-C15E-4108-AE40-4C209767C473}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -57,6 +59,10 @@ Global
 		{9673D9AD-53CE-4768-A74D-E8719A9D8FBD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9673D9AD-53CE-4768-A74D-E8719A9D8FBD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9673D9AD-53CE-4768-A74D-E8719A9D8FBD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F6604E25-C15E-4108-AE40-4C209767C473}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F6604E25-C15E-4108-AE40-4C209767C473}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F6604E25-C15E-4108-AE40-4C209767C473}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F6604E25-C15E-4108-AE40-4C209767C473}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -65,6 +71,7 @@ Global
 		{62064F40-927E-4421-AF63-AAD08A8CC360} = {AF6E590F-F997-442E-8F77-356C7E4DF275}
 		{E9C789C3-E611-4BF1-BCEF-73F2F4BF13BB} = {75CB1268-E052-4A3F-8022-2C21C84D9B32}
 		{9673D9AD-53CE-4768-A74D-E8719A9D8FBD} = {AF6E590F-F997-442E-8F77-356C7E4DF275}
+		{F6604E25-C15E-4108-AE40-4C209767C473} = {0977BFBE-C5F3-4B90-9F9E-77061320CB9D}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {552BE595-AF8A-4BA2-9F45-D3CED6737ABB}

--- a/src/Louis.Logging/LogInterpolatedStringHandler.Debug.cs
+++ b/src/Louis.Logging/LogInterpolatedStringHandler.Debug.cs
@@ -29,7 +29,7 @@ partial struct LogInterpolatedStringHandler
         /// </summary>
         public Debug(int literalLength, int formattedCount, ILogger @this, out bool isEnabled)
         {
-            _handler = new(literalLength, formattedCount, @this, LogLevel.Critical, out isEnabled);
+            _handler = new(literalLength, formattedCount, @this, LogLevel.Debug, out isEnabled);
         }
 
         internal bool IsEnabled => _handler.IsEnabled;

--- a/src/Louis.Logging/LogInterpolatedStringHandler.Error.cs
+++ b/src/Louis.Logging/LogInterpolatedStringHandler.Error.cs
@@ -31,7 +31,7 @@ partial struct LogInterpolatedStringHandler
         /// </summary>
         public Error(int literalLength, int formattedCount, ILogger @this, out bool isEnabled)
         {
-            _handler = new(literalLength, formattedCount, @this, LogLevel.Critical, out isEnabled);
+            _handler = new(literalLength, formattedCount, @this, LogLevel.Error, out isEnabled);
         }
 
         internal bool IsEnabled => _handler.IsEnabled;

--- a/src/Louis.Logging/LogInterpolatedStringHandler.Information.cs
+++ b/src/Louis.Logging/LogInterpolatedStringHandler.Information.cs
@@ -29,7 +29,7 @@ partial struct LogInterpolatedStringHandler
         /// </summary>
         public Information(int literalLength, int formattedCount, ILogger @this, out bool isEnabled)
         {
-            _handler = new(literalLength, formattedCount, @this, LogLevel.Critical, out isEnabled);
+            _handler = new(literalLength, formattedCount, @this, LogLevel.Information, out isEnabled);
         }
 
         internal bool IsEnabled => _handler.IsEnabled;

--- a/src/Louis.Logging/LogInterpolatedStringHandler.Trace.cs
+++ b/src/Louis.Logging/LogInterpolatedStringHandler.Trace.cs
@@ -29,7 +29,7 @@ partial struct LogInterpolatedStringHandler
         /// </summary>
         public Trace(int literalLength, int formattedCount, ILogger @this, out bool isEnabled)
         {
-            _handler = new(literalLength, formattedCount, @this, LogLevel.Critical, out isEnabled);
+            _handler = new(literalLength, formattedCount, @this, LogLevel.Trace, out isEnabled);
         }
 
         internal bool IsEnabled => _handler.IsEnabled;

--- a/src/Louis.Logging/LogInterpolatedStringHandler.Warning.cs
+++ b/src/Louis.Logging/LogInterpolatedStringHandler.Warning.cs
@@ -29,7 +29,7 @@ partial struct LogInterpolatedStringHandler
         /// </summary>
         public Warning(int literalLength, int formattedCount, ILogger @this, out bool isEnabled)
         {
-            _handler = new(literalLength, formattedCount, @this, LogLevel.Critical, out isEnabled);
+            _handler = new(literalLength, formattedCount, @this, LogLevel.Warning, out isEnabled);
         }
 
         internal bool IsEnabled => _handler.IsEnabled;

--- a/tests/LoggingTests/GlobalUsings.cs
+++ b/tests/LoggingTests/GlobalUsings.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) Tenacom and contributors. Licensed under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+global using System;
+global using FluentAssertions;
+global using Internal;
+global using Louis.Logging;
+global using Microsoft.Extensions.Logging;
+global using Xunit;

--- a/tests/LoggingTests/Internal/NullScope.cs
+++ b/tests/LoggingTests/Internal/NullScope.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Tenacom and contributors. Licensed under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Internal;
+
+internal sealed class NullScope : IDisposable
+{
+    private NullScope()
+    {
+    }
+
+    public static NullScope Instance { get; } = new();
+
+    public void Dispose()
+    {
+    }
+}

--- a/tests/LoggingTests/Internal/TestLogger.cs
+++ b/tests/LoggingTests/Internal/TestLogger.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Tenacom and contributors. Licensed under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Internal;
+
+public class TestLogger : ILogger
+{
+    private readonly bool _enableTrace;
+    private readonly bool _enableDebug;
+    private readonly bool _enableInformation;
+    private readonly bool _enableWarning;
+    private readonly bool _enableError;
+    private readonly bool _enableCritical;
+
+    internal TestLogger(
+        bool? enableTrace = null,
+        bool? enableDebug = null,
+        bool? enableInformation = null,
+        bool? enableWarning = null,
+        bool? enableError = null,
+        bool? enableCritical = null,
+        bool enableOthers = false)
+    {
+        _enableTrace = enableTrace ?? enableOthers;
+        _enableDebug = enableDebug ?? enableOthers;
+        _enableInformation = enableInformation ?? enableOthers;
+        _enableWarning = enableWarning ?? enableOthers;
+        _enableError = enableError ?? enableOthers;
+        _enableCritical = enableCritical ?? enableOthers;
+    }
+
+    public IDisposable? BeginScope<TState>(TState state)
+        where TState : notnull
+        => NullScope.Instance;
+
+    public bool IsEnabled(LogLevel logLevel)
+        => logLevel switch {
+            LogLevel.Trace => _enableTrace,
+            LogLevel.Debug => _enableDebug,
+            LogLevel.Information => _enableInformation,
+            LogLevel.Warning => _enableWarning,
+            LogLevel.Error => _enableError,
+            LogLevel.Critical => _enableCritical,
+            _ => false,
+        };
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+    {
+    }
+}

--- a/tests/LoggingTests/LoggingTests.csproj
+++ b/tests/LoggingTests/LoggingTests.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TestProjectType>UnitTest</TestProjectType>
+    <TargetFrameworks>net48;net6.0;net7.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <!--
+    This assembly is not going to interoperate with other assemblies.
+    Besides, the type names used here are not apt to cause ambiguities.
+    Therefore there is no need for a root namespace: let's save ourselves some declarations.
+  -->
+  <PropertyGroup>
+    <RootNamespace />
+    <NoWarn>$(NoWarn);CA1050</NoWarn> <!--Declare types in namespaces -->
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Louis.Logging\Louis.Logging.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" PrivateAssets="all" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="FluentAssertions.Analyzers" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" />
+  </ItemGroup>
+
+</Project>

--- a/tests/LoggingTests/Regressions/Issue24.cs
+++ b/tests/LoggingTests/Regressions/Issue24.cs
@@ -1,0 +1,113 @@
+﻿// Copyright (c) Tenacom and contributors. Licensed under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Regressions;
+
+public class Issue24
+{
+    private const string GotchaMessage = "Gotcha!";
+
+    [Fact]
+    public void LogTrace_WhenTraceEnabled_EvaluatesInterpolations()
+    {
+        var logger = new TestLogger(enableTrace: true, enableOthers: false);
+        logger.Invoking(l => l.LogTrace($"Let's go {Boom()}!"))
+              .Should().Throw<InvalidOperationException>()
+              .WithMessage(GotchaMessage);
+    }
+
+    [Fact]
+    public void LogTrace_WhenTraceNotEnabled_DoesNotEvaluateInterpolations()
+    {
+        var logger = new TestLogger(enableTrace: false, enableOthers: true);
+        logger.Invoking(l => l.LogTrace($"Let's go {Boom()}!"))
+              .Should().NotThrow();
+    }
+
+    [Fact]
+    public void LogDebug_WhenDebugEnabled_EvaluatesInterpolations()
+    {
+        var logger = new TestLogger(enableDebug: true, enableOthers: false);
+        logger.Invoking(l => l.LogDebug($"Let's go {Boom()}!"))
+              .Should().Throw<InvalidOperationException>()
+              .WithMessage(GotchaMessage);
+    }
+
+    [Fact]
+    public void LogDebug_WhenDebugNotEnabled_DoesNotEvaluateInterpolations()
+    {
+        var logger = new TestLogger(enableDebug: false, enableOthers: true);
+        logger.Invoking(l => l.LogDebug($"Let's go {Boom()}!"))
+              .Should().NotThrow();
+    }
+
+    [Fact]
+    public void LogInformation_WhenInformationEnabled_EvaluatesInterpolations()
+    {
+        var logger = new TestLogger(enableInformation: true, enableOthers: false);
+        logger.Invoking(l => l.LogInformation($"Let's go {Boom()}!"))
+              .Should().Throw<InvalidOperationException>()
+              .WithMessage(GotchaMessage);
+    }
+
+    [Fact]
+    public void LogInformation_WhenInformationNotEnabled_DoesNotEvaluateInterpolations()
+    {
+        var logger = new TestLogger(enableInformation: false, enableOthers: true);
+        logger.Invoking(l => l.LogInformation($"Let's go {Boom()}!"))
+              .Should().NotThrow();
+    }
+
+    [Fact]
+    public void LogWarning_WhenWarningEnabled_EvaluatesInterpolations()
+    {
+        var logger = new TestLogger(enableWarning: true, enableOthers: false);
+        logger.Invoking(l => l.LogWarning($"Let's go {Boom()}!"))
+              .Should().Throw<InvalidOperationException>()
+              .WithMessage(GotchaMessage);
+    }
+
+    [Fact]
+    public void LogWarning_WhenWarningNotEnabled_DoesNotEvaluateInterpolations()
+    {
+        var logger = new TestLogger(enableWarning: false, enableOthers: true);
+        logger.Invoking(l => l.LogWarning($"Let's go {Boom()}!"))
+              .Should().NotThrow();
+    }
+
+    [Fact]
+    public void LogError_WhenErrorEnabled_EvaluatesInterpolations()
+    {
+        var logger = new TestLogger(enableError: true, enableOthers: false);
+        logger.Invoking(l => l.LogError($"Let's go {Boom()}!"))
+              .Should().Throw<InvalidOperationException>()
+              .WithMessage(GotchaMessage);
+    }
+
+    [Fact]
+    public void LogError_WhenErrorNotEnabled_DoesNotEvaluateInterpolations()
+    {
+        var logger = new TestLogger(enableError: false, enableOthers: true);
+        logger.Invoking(l => l.LogError($"Let's go {Boom()}!"))
+              .Should().NotThrow();
+    }
+
+    [Fact]
+    public void LogCritical_WhenCriticalEnabled_EvaluatesInterpolations()
+    {
+        var logger = new TestLogger(enableCritical: true, enableOthers: false);
+        logger.Invoking(l => l.LogCritical($"Let's go {Boom()}!"))
+              .Should().Throw<InvalidOperationException>()
+              .WithMessage(GotchaMessage);
+    }
+
+    [Fact]
+    public void LogCritical_WhenCriticalNotEnabled_DoesNotEvaluateInterpolations()
+    {
+        var logger = new TestLogger(enableCritical: false, enableOthers: true);
+        logger.Invoking(l => l.LogCritical($"Let's go {Boom()}!"))
+              .Should().NotThrow();
+    }
+
+    private int Boom() => throw new InvalidOperationException(GotchaMessage);
+}


### PR DESCRIPTION
## Proposed changes

Fix #24 and add regression tests.

Add the necessary dependencies for tests (xUnit, FluentAssertions).

### Checklist of related issues / discussions

- [x] Fixes #24

## Types of changes

This pull request introduces the following types of changes:

<!-- Put an `x` in the boxes that apply. -->

- [x] Bug fix <!-- This includes changes to tests and XML documentation as applicable. -->
- [ ] New feature <!-- This includes changes to tests and XML documentation as applicable. -->
- [ ] Test addition / update (no changes to non-test code)
- [ ] Refactor (no changes in public API syntax or semantics)
- [ ] Performance improvement (no changes in public API syntax or semantics)
- [ ] Documentation (`docs` directory) update
- [x] Dependency addition / update
- [ ] Changes to the build scripts
- [ ] Changes to CI (workflows, bot / app configurations)
- [ ] Changes to repository files (`.gitattributes`, `.gitignore`)
- [ ] Other

### Breaking changes

This pull request introduces breaking changes:

- [ ] Yes
- [x] No

## Checklist

- **For all types of changes:**
  - [x] I have read the [Code of Conduct](https://github.com/Tenacom/.github/blob/main/CODE_OF_CONDUCT.md) and agree to be bound by it
  - [x] I have read the [Contributor Guide](https://github.com/Tenacom/.github/blob/main/CONTRIBUTING.md) and agree to follow it
- **For code changes only:**
  - [x] The project builds on my machine, via the provided build script, _with zero warnings_
  - [x] I have added tests that prove my feature works / my fix is effective
  - [ ] ~~I have added / modified XML documentation according to changes in code~~ _(not applicable)_
  - [ ] ~~I have checked that all the links I added or modified in XML documentation point to their intended destination~~ _(not applicable)_
- **For documentation changes (`docs` directory) only:**
  - [ ] I have built and tested documentation locally
  - [ ] I have checked that all the links I added or modified point to their intended destination
