### PR TITLE
Add PrefixingLogger class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ logs/
 tools/
 
 # Testing
-TestResults/
+**/TestResults/
 
 # Visual Studio
 **/bin/

--- a/Louis.sln
+++ b/Louis.sln
@@ -26,6 +26,9 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{AF6E590F-F997-442E-8F77-356C7E4DF275}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{0977BFBE-C5F3-4B90-9F9E-77061320CB9D}"
+	ProjectSection(SolutionItems) = preProject
+		tests\Common.targets = tests\Common.targets
+	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Louis", "src\Louis\Louis.csproj", "{62064F40-927E-4421-AF63-AAD08A8CC360}"
 EndProject

--- a/src/Louis.Logging/PrefixingLogger.cs
+++ b/src/Louis.Logging/PrefixingLogger.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (c) Tenacom and contributors. Licensed under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using CommunityToolkit.Diagnostics;
+using Microsoft.Extensions.Logging;
+
+namespace Louis.Logging;
+
+/// <summary>
+/// Wraps an existing logger, prefixing all log messages with a given string.
+/// </summary>
+public sealed class PrefixingLogger : ILogger
+{
+    private readonly ILogger _realWrappedLogger;
+    private readonly string _realPrefix;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PrefixingLogger"/> class.
+    /// </summary>
+    /// <param name="logger">The <see cref="ILogger"/> interface to wrap.</param>
+    /// <param name="prefix">The desired prefix for log messages.</param>
+    /// <exception cref="ArgumentNullException">
+    /// <para><paramref name="logger"/> is <see langword="null"/>.</para>
+    /// <para>- or -</para>
+    /// <para><paramref name="prefix"/> is <see langword="null"/>.</para>
+    /// </exception>
+    public PrefixingLogger(ILogger logger, string prefix)
+    {
+        Guard.IsNotNull(logger);
+        Guard.IsNotNull(prefix);
+        WrappedLogger = logger;
+        Prefix = prefix;
+        if (WrappedLogger is PrefixingLogger prefixingLogger)
+        {
+            _realWrappedLogger = prefixingLogger._realWrappedLogger;
+            _realPrefix = prefix + prefixingLogger._realPrefix;
+        }
+        else
+        {
+            _realWrappedLogger = WrappedLogger;
+            _realPrefix = Prefix;
+        }
+    }
+
+    /// <summary>
+    /// Gets the logger wrapped by this instance.
+    /// </summary>
+    public ILogger WrappedLogger { get; }
+
+    /// <summary>
+    /// Gets the prefix applied to log messages.
+    /// </summary>
+    public string Prefix { get; }
+
+    /// <inheritdoc/>
+    IDisposable? ILogger.BeginScope<TState>(TState state) => WrappedLogger.BeginScope(state);
+
+    /// <inheritdoc/>
+    bool ILogger.IsEnabled(LogLevel logLevel) => WrappedLogger.IsEnabled(logLevel);
+
+    /// <inheritdoc/>
+    void ILogger.Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        => _realWrappedLogger.Log(logLevel, eventId, state, exception, (s, e) => _realPrefix + formatter(s, e));
+}

--- a/src/Louis.Logging/PublicAPI.Unshipped.txt
+++ b/src/Louis.Logging/PublicAPI.Unshipped.txt
@@ -42,6 +42,10 @@ Louis.Logging.LogInterpolatedStringHandler.Warning.AppendFormatted<T>(T? value, 
 Louis.Logging.LogInterpolatedStringHandler.Warning.AppendLiteral(string! s) -> void
 Louis.Logging.LogInterpolatedStringHandler.Warning.Warning() -> void
 Louis.Logging.LogInterpolatedStringHandler.Warning.Warning(int literalLength, int formattedCount, Microsoft.Extensions.Logging.ILogger! this, out bool isEnabled) -> void
+Louis.Logging.PrefixingLogger
+Louis.Logging.PrefixingLogger.Prefix.get -> string!
+Louis.Logging.PrefixingLogger.PrefixingLogger(Microsoft.Extensions.Logging.ILogger! logger, string! prefix) -> void
+Louis.Logging.PrefixingLogger.WrappedLogger.get -> Microsoft.Extensions.Logging.ILogger!
 static Louis.Logging.LoggerExtensions.Log(this Microsoft.Extensions.Logging.ILogger! this, Microsoft.Extensions.Logging.LogLevel logLevel, Microsoft.Extensions.Logging.EventId eventId, ref Louis.Logging.LogInterpolatedStringHandler message) -> void
 static Louis.Logging.LoggerExtensions.Log(this Microsoft.Extensions.Logging.ILogger! this, Microsoft.Extensions.Logging.LogLevel logLevel, Microsoft.Extensions.Logging.EventId eventId, string! message) -> void
 static Louis.Logging.LoggerExtensions.Log(this Microsoft.Extensions.Logging.ILogger! this, Microsoft.Extensions.Logging.LogLevel logLevel, Microsoft.Extensions.Logging.EventId eventId, System.Exception? exception, ref Louis.Logging.LogInterpolatedStringHandler message) -> void

--- a/tests/Common.targets
+++ b/tests/Common.targets
@@ -1,0 +1,28 @@
+<Project>
+
+  <!-- Common build options for test projects -->
+  <PropertyGroup Condition="'$(TestProjectType)' != ''">
+
+    <!--
+        This assembly is not going to interoperate with other assemblies.
+        Besides, the type names used here are not apt to cause ambiguities.
+        Therefore there is no need for a root namespace: let's save ourselves some declarations.
+    -->
+    <RootNamespace />
+
+    <!-- No need for public API analyzers -->
+    <UsePublicApiAnalyzers>false</UsePublicApiAnalyzers>
+
+    <!-- Disable some warnings that have no sense in test projects -->
+    <NoWarn>$(NoWarn);CA1050</NoWarn> <!-- Declare types in namespaces -->
+    <NoWarn>$(NoWarn);CA1707</NoWarn> <!-- Identifiers should not contain underscores -->
+    <NoWarn>$(NoWarn);IDE0058</NoWarn> <!-- Expression value is never used -->
+
+  </PropertyGroup>
+
+  <!-- Hide test result files in Visual Studio -->
+  <ItemGroup Condition="'$(TestProjectType)' != ''">
+    <None Remove="TestResults\**" />
+  </ItemGroup>
+
+</Project>

--- a/tests/LoggingTests/Internal/TestLogger.cs
+++ b/tests/LoggingTests/Internal/TestLogger.cs
@@ -46,6 +46,8 @@ public class TestLogger : ILogger
         _enableCritical = enableCritical ?? enableOthers;
     }
 
+    public (LogLevel LogLevel, bool WasEnabled, string Message) LastEntry { get; private set; } = (LogLevel.None, false, string.Empty);
+
     public IDisposable? BeginScope<TState>(TState state)
         where TState : notnull
         => NullScope.Instance;
@@ -62,6 +64,5 @@ public class TestLogger : ILogger
         };
 
     public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
-    {
-    }
+        => LastEntry = (logLevel, IsEnabled(logLevel), formatter(state, exception));
 }

--- a/tests/LoggingTests/Internal/TestLogger.cs
+++ b/tests/LoggingTests/Internal/TestLogger.cs
@@ -12,6 +12,23 @@ public class TestLogger : ILogger
     private readonly bool _enableError;
     private readonly bool _enableCritical;
 
+    internal TestLogger(bool enable = true)
+        : this(enableOthers: enable)
+    {
+    }
+
+    internal TestLogger(LogLevel singleLevel, bool enable = true)
+        : this(
+            enableTrace: singleLevel == LogLevel.Trace ? enable : null,
+            enableDebug: singleLevel == LogLevel.Debug ? enable : null,
+            enableInformation: singleLevel == LogLevel.Information ? enable : null,
+            enableWarning: singleLevel == LogLevel.Warning ? enable : null,
+            enableError: singleLevel == LogLevel.Error ? enable : null,
+            enableCritical: singleLevel == LogLevel.Critical ? enable : null,
+            enableOthers: !enable)
+    {
+    }
+
     internal TestLogger(
         bool? enableTrace = null,
         bool? enableDebug = null,

--- a/tests/LoggingTests/LoggingTests.csproj
+++ b/tests/LoggingTests/LoggingTests.csproj
@@ -3,16 +3,7 @@
   <PropertyGroup>
     <TestProjectType>UnitTest</TestProjectType>
     <TargetFrameworks>net48;net6.0;net7.0</TargetFrameworks>
-  </PropertyGroup>
-
-  <!--
-    This assembly is not going to interoperate with other assemblies.
-    Besides, the type names used here are not apt to cause ambiguities.
-    Therefore there is no need for a root namespace: let's save ourselves some declarations.
-  -->
-  <PropertyGroup>
-    <RootNamespace />
-    <NoWarn>$(NoWarn);CA1050</NoWarn> <!--Declare types in namespaces -->
+    <CLSCompliant>false</CLSCompliant>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/LoggingTests/UnitTests/PrefixingLoggerTests.cs
+++ b/tests/LoggingTests/UnitTests/PrefixingLoggerTests.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) Tenacom and contributors. Licensed under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace UnitTests;
+
+public sealed class PrefixingLoggerTests
+{
+    [Fact]
+    public void Constructor_WithLoggerNull_ThrowsArgumentNullException()
+    {
+        var func = () => new PrefixingLogger(null!, "Prefix:");
+        func.Should().Throw<ArgumentNullException>()
+            .Where(e => e.ParamName == "logger");
+    }
+
+    [Fact]
+    public void Constructor_WithPrefixNull_ThrowsArgumentNullException()
+    {
+        var logger = new TestLogger(enable: true);
+        var func = () => new PrefixingLogger(logger, null!);
+        func.Should().Throw<ArgumentNullException>()
+            .Where(e => e.ParamName == "prefix");
+    }
+
+    [Fact]
+    public void WrappedLogger_IsTheLoggerPassedToConstructor()
+    {
+        var logger = new TestLogger(enable: true);
+        var prefixingLogger1 = new PrefixingLogger(logger, "foo,");
+        var prefixingLogger2 = new PrefixingLogger(prefixingLogger1, "bar,");
+        prefixingLogger1.WrappedLogger.Should().Be(logger);
+        prefixingLogger2.WrappedLogger.Should().Be(prefixingLogger1);
+    }
+
+    [Fact]
+    public void Prefix_IsThePrefixPassedToConstructor()
+    {
+        var logger = new TestLogger(enable: true);
+        var prefixingLogger1 = new PrefixingLogger(logger, "foo,");
+        var prefixingLogger2 = new PrefixingLogger(prefixingLogger1, "bar,");
+        prefixingLogger1.Prefix.Should().Be("foo,");
+        prefixingLogger2.Prefix.Should().Be("bar,");
+    }
+
+    [Fact]
+    public void Log_WithPrefix_PrefixesLogMessages()
+    {
+        var logger = new TestLogger(enable: true);
+        var prefixingLogger = new PrefixingLogger(logger, "foo,");
+        prefixingLogger.LogInformation("bar");
+        logger.LastEntry.Message.Should().Be("foo,bar");
+    }
+
+    [Fact]
+    public void Log_WithNestedPrefixingLoggers_ConcatenatesPrefixes()
+    {
+        var logger = new TestLogger(enable: true);
+        var prefixingLogger1 = new PrefixingLogger(logger, "foo,");
+        var prefixingLogger2 = new PrefixingLogger(prefixingLogger1, "bar,");
+        prefixingLogger2.LogInformation("baz");
+        logger.LastEntry.Message.Should().Be("bar,foo,baz");
+    }
+}


### PR DESCRIPTION
## Proposed changes

See issue #26 (the class is provisionally called `PrefixedLogger` there).

Plus a couple infrastructural improvements:

- correct `TestResults/` to `**/TestResults/` in `.gitignore`;
- extract common build options for test projects into a `tests\Common.targets` file.

### Checklist of related issues / discussions

- [x] Closes #26

## Types of changes

This pull request introduces the following types of changes:

- [ ] Bug fix <!-- This includes changes to tests and XML documentation as applicable. -->
- [x] New feature <!-- This includes changes to tests and XML documentation as applicable. -->
- [x] Test addition / update (no changes to non-test code)
- [ ] Refactor (no changes in public API syntax or semantics)
- [ ] Performance improvement (no changes in public API syntax or semantics)
- [ ] Documentation (`docs` directory) update
- [ ] Dependency addition / update
- [ ] Changes to the build scripts
- [ ] Changes to CI (workflows, bot / app configurations)
- [x] Changes to repository files (`.gitattributes`, `.gitignore`)
- [ ] Other

### Breaking changes

This pull request introduces breaking changes:

- [ ] Yes
- [x] No

## Checklist

- **For all types of changes:**
  - [x] I have read the [Code of Conduct](https://github.com/Tenacom/.github/blob/main/CODE_OF_CONDUCT.md) and agree to be bound by it
  - [x] I have read the [Contributor Guide](https://github.com/Tenacom/.github/blob/main/CONTRIBUTING.md) and agree to follow it
- **For code changes only:**
  - [x] The project builds on my machine, via the provided build script, _with zero warnings_
  - [x] I have added tests that prove my feature works / my fix is effective
  - [x] I have added / modified XML documentation according to changes in code
  - [x] I have checked that all the links I added or modified in XML documentation point to their intended destination
- **For documentation changes (`docs` directory) only:**
  - [ ] I have built and tested documentation locally
  - [ ] I have checked that all the links I added or modified point to their intended destination
