### PR TITLE
Minor fixes to testing code

### DIFF
--- a/src/Louis.Logging/LogInterpolatedStringHandler.Critical.cs
+++ b/src/Louis.Logging/LogInterpolatedStringHandler.Critical.cs
@@ -20,9 +20,9 @@ partial struct LogInterpolatedStringHandler
     /// This type is only meant for internal use by L.o.U.I.S. and should not be used directly.
     /// </summary>
     [InterpolatedStringHandler]
-    public readonly ref struct Critical
+    public ref struct Critical
     {
-        private readonly LogInterpolatedStringHandler _handler;
+        private LogInterpolatedStringHandler _handler;
 
         /// <summary>
         /// This constructor is only meant for internal use by L.o.U.I.S. and should not be used directly.

--- a/src/Louis.Logging/LogInterpolatedStringHandler.Critical.cs
+++ b/src/Louis.Logging/LogInterpolatedStringHandler.Critical.cs
@@ -43,7 +43,7 @@ partial struct LogInterpolatedStringHandler
         /// This method is only meant for internal use by L.o.U.I.S. and should not be used directly.
         /// </summary>
 #pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters - We need CallerArgumentExpression here
-        public void AppendFormatted(object? value, int alignment = 0, string? format = null, [CallerArgumentExpression("value")] string name = "")
+        public void AppendFormatted(object? value, int alignment = 0, string? format = null, [CallerArgumentExpression(nameof(value))] string name = "")
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
             => _handler.AppendFormatted(value, alignment, format, name);
 
@@ -51,7 +51,7 @@ partial struct LogInterpolatedStringHandler
         /// This method is only meant for internal use by L.o.U.I.S. and should not be used directly.
         /// </summary>
 #pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters - We need CallerArgumentExpression here
-        public void AppendFormatted<T>(T? value, int alignment = 0, string? format = null, [CallerArgumentExpression("value")] string name = "")
+        public void AppendFormatted<T>(T? value, int alignment = 0, string? format = null, [CallerArgumentExpression(nameof(value))] string name = "")
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
             where T : struct
             => _handler.AppendFormatted(value, alignment, format, name);

--- a/src/Louis.Logging/LogInterpolatedStringHandler.Debug.cs
+++ b/src/Louis.Logging/LogInterpolatedStringHandler.Debug.cs
@@ -20,9 +20,9 @@ partial struct LogInterpolatedStringHandler
     /// This type is only meant for internal use by L.o.U.I.S. and should not be used directly.
     /// </summary>
     [InterpolatedStringHandler]
-    public readonly ref struct Debug
+    public ref struct Debug
     {
-        private readonly LogInterpolatedStringHandler _handler;
+        private LogInterpolatedStringHandler _handler;
 
         /// <summary>
         /// This constructor is only meant for internal use by L.o.U.I.S. and should not be used directly.

--- a/src/Louis.Logging/LogInterpolatedStringHandler.Debug.cs
+++ b/src/Louis.Logging/LogInterpolatedStringHandler.Debug.cs
@@ -43,7 +43,7 @@ partial struct LogInterpolatedStringHandler
         /// This method is only meant for internal use by L.o.U.I.S. and should not be used directly.
         /// </summary>
 #pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters - We need CallerArgumentExpression here
-        public void AppendFormatted(object? value, int alignment = 0, string? format = null, [CallerArgumentExpression("value")] string name = "")
+        public void AppendFormatted(object? value, int alignment = 0, string? format = null, [CallerArgumentExpression(nameof(value))] string name = "")
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
             => _handler.AppendFormatted(value, alignment, format, name);
 
@@ -51,7 +51,7 @@ partial struct LogInterpolatedStringHandler
         /// This method is only meant for internal use by L.o.U.I.S. and should not be used directly.
         /// </summary>
 #pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters - We need CallerArgumentExpression here
-        public void AppendFormatted<T>(T? value, int alignment = 0, string? format = null, [CallerArgumentExpression("value")] string name = "")
+        public void AppendFormatted<T>(T? value, int alignment = 0, string? format = null, [CallerArgumentExpression(nameof(value))] string name = "")
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
             where T : struct
             => _handler.AppendFormatted(value, alignment, format, name);

--- a/src/Louis.Logging/LogInterpolatedStringHandler.Error.cs
+++ b/src/Louis.Logging/LogInterpolatedStringHandler.Error.cs
@@ -45,7 +45,7 @@ partial struct LogInterpolatedStringHandler
         /// This method is only meant for internal use by L.o.U.I.S. and should not be used directly.
         /// </summary>
 #pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters - We need CallerArgumentExpression here
-        public void AppendFormatted(object? value, int alignment = 0, string? format = null, [CallerArgumentExpression("value")] string name = "")
+        public void AppendFormatted(object? value, int alignment = 0, string? format = null, [CallerArgumentExpression(nameof(value))] string name = "")
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
             => _handler.AppendFormatted(value, alignment, format, name);
 
@@ -53,7 +53,7 @@ partial struct LogInterpolatedStringHandler
         /// This method is only meant for internal use by L.o.U.I.S. and should not be used directly.
         /// </summary>
 #pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters - We need CallerArgumentExpression here
-        public void AppendFormatted<T>(T? value, int alignment = 0, string? format = null, [CallerArgumentExpression("value")] string name = "")
+        public void AppendFormatted<T>(T? value, int alignment = 0, string? format = null, [CallerArgumentExpression(nameof(value))] string name = "")
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
             where T : struct
             => _handler.AppendFormatted(value, alignment, format, name);

--- a/src/Louis.Logging/LogInterpolatedStringHandler.Error.cs
+++ b/src/Louis.Logging/LogInterpolatedStringHandler.Error.cs
@@ -21,10 +21,10 @@ partial struct LogInterpolatedStringHandler
     /// </summary>
     [InterpolatedStringHandler]
 #pragma warning disable CA1716 // Identifiers should not match keywords - This type is not meant to be used directly anyway.
-    public readonly ref struct Error
+    public ref struct Error
 #pragma warning restore CA1716 // Identifiers should not match keywords
     {
-        private readonly LogInterpolatedStringHandler _handler;
+        private LogInterpolatedStringHandler _handler;
 
         /// <summary>
         /// This constructor is only meant for internal use by L.o.U.I.S. and should not be used directly.

--- a/src/Louis.Logging/LogInterpolatedStringHandler.Information.cs
+++ b/src/Louis.Logging/LogInterpolatedStringHandler.Information.cs
@@ -20,9 +20,9 @@ partial struct LogInterpolatedStringHandler
     /// This type is only meant for internal use by L.o.U.I.S. and should not be used directly.
     /// </summary>
     [InterpolatedStringHandler]
-    public readonly ref struct Information
+    public ref struct Information
     {
-        private readonly LogInterpolatedStringHandler _handler;
+        private LogInterpolatedStringHandler _handler;
 
         /// <summary>
         /// This constructor is only meant for internal use by L.o.U.I.S. and should not be used directly.

--- a/src/Louis.Logging/LogInterpolatedStringHandler.Information.cs
+++ b/src/Louis.Logging/LogInterpolatedStringHandler.Information.cs
@@ -43,7 +43,7 @@ partial struct LogInterpolatedStringHandler
         /// This method is only meant for internal use by L.o.U.I.S. and should not be used directly.
         /// </summary>
 #pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters - We need CallerArgumentExpression here
-        public void AppendFormatted(object? value, int alignment = 0, string? format = null, [CallerArgumentExpression("value")] string name = "")
+        public void AppendFormatted(object? value, int alignment = 0, string? format = null, [CallerArgumentExpression(nameof(value))] string name = "")
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
             => _handler.AppendFormatted(value, alignment, format, name);
 
@@ -51,7 +51,7 @@ partial struct LogInterpolatedStringHandler
         /// This method is only meant for internal use by L.o.U.I.S. and should not be used directly.
         /// </summary>
 #pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters - We need CallerArgumentExpression here
-        public void AppendFormatted<T>(T? value, int alignment = 0, string? format = null, [CallerArgumentExpression("value")] string name = "")
+        public void AppendFormatted<T>(T? value, int alignment = 0, string? format = null, [CallerArgumentExpression(nameof(value))] string name = "")
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
             where T : struct
             => _handler.AppendFormatted(value, alignment, format, name);

--- a/src/Louis.Logging/LogInterpolatedStringHandler.Trace.cs
+++ b/src/Louis.Logging/LogInterpolatedStringHandler.Trace.cs
@@ -20,9 +20,9 @@ partial struct LogInterpolatedStringHandler
     /// This type is only meant for internal use by L.o.U.I.S. and should not be used directly.
     /// </summary>
     [InterpolatedStringHandler]
-    public readonly ref struct Trace
+    public ref struct Trace
     {
-        private readonly LogInterpolatedStringHandler _handler;
+        private LogInterpolatedStringHandler _handler;
 
         /// <summary>
         /// This constructor is only meant for internal use by L.o.U.I.S. and should not be used directly.

--- a/src/Louis.Logging/LogInterpolatedStringHandler.Trace.cs
+++ b/src/Louis.Logging/LogInterpolatedStringHandler.Trace.cs
@@ -43,7 +43,7 @@ partial struct LogInterpolatedStringHandler
         /// This method is only meant for internal use by L.o.U.I.S. and should not be used directly.
         /// </summary>
 #pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters - We need CallerArgumentExpression here
-        public void AppendFormatted(object? value, int alignment = 0, string? format = null, [CallerArgumentExpression("value")] string name = "")
+        public void AppendFormatted(object? value, int alignment = 0, string? format = null, [CallerArgumentExpression(nameof(value))] string name = "")
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
             => _handler.AppendFormatted(value, alignment, format, name);
 
@@ -51,7 +51,7 @@ partial struct LogInterpolatedStringHandler
         /// This method is only meant for internal use by L.o.U.I.S. and should not be used directly.
         /// </summary>
 #pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters - We need CallerArgumentExpression here
-        public void AppendFormatted<T>(T? value, int alignment = 0, string? format = null, [CallerArgumentExpression("value")] string name = "")
+        public void AppendFormatted<T>(T? value, int alignment = 0, string? format = null, [CallerArgumentExpression(nameof(value))] string name = "")
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
             where T : struct
             => _handler.AppendFormatted(value, alignment, format, name);

--- a/src/Louis.Logging/LogInterpolatedStringHandler.Warning.cs
+++ b/src/Louis.Logging/LogInterpolatedStringHandler.Warning.cs
@@ -20,9 +20,9 @@ partial struct LogInterpolatedStringHandler
     /// This type is only meant for internal use by L.o.U.I.S. and should not be used directly.
     /// </summary>
     [InterpolatedStringHandler]
-    public readonly ref struct Warning
+    public ref struct Warning
     {
-        private readonly LogInterpolatedStringHandler _handler;
+        private LogInterpolatedStringHandler _handler;
 
         /// <summary>
         /// This constructor is only meant for internal use by L.o.U.I.S. and should not be used directly.

--- a/src/Louis.Logging/LogInterpolatedStringHandler.Warning.cs
+++ b/src/Louis.Logging/LogInterpolatedStringHandler.Warning.cs
@@ -43,7 +43,7 @@ partial struct LogInterpolatedStringHandler
         /// This method is only meant for internal use by L.o.U.I.S. and should not be used directly.
         /// </summary>
 #pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters - We need CallerArgumentExpression here
-        public void AppendFormatted(object? value, int alignment = 0, string? format = null, [CallerArgumentExpression("value")] string name = "")
+        public void AppendFormatted(object? value, int alignment = 0, string? format = null, [CallerArgumentExpression(nameof(value))] string name = "")
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
             => _handler.AppendFormatted(value, alignment, format, name);
 
@@ -51,7 +51,7 @@ partial struct LogInterpolatedStringHandler
         /// This method is only meant for internal use by L.o.U.I.S. and should not be used directly.
         /// </summary>
 #pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters - We need CallerArgumentExpression here
-        public void AppendFormatted<T>(T? value, int alignment = 0, string? format = null, [CallerArgumentExpression("value")] string name = "")
+        public void AppendFormatted<T>(T? value, int alignment = 0, string? format = null, [CallerArgumentExpression(nameof(value))] string name = "")
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
             where T : struct
             => _handler.AppendFormatted(value, alignment, format, name);

--- a/src/Louis.Logging/LogInterpolatedStringHandler.cs
+++ b/src/Louis.Logging/LogInterpolatedStringHandler.cs
@@ -91,7 +91,7 @@ public ref partial struct LogInterpolatedStringHandler
     /// This method is only meant for internal use by L.o.U.I.S. and should not be used directly.
     /// </summary>
 #pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters - We need CallerArgumentExpression here
-    public void AppendFormatted(object? value, int alignment = 0, string? format = null, [CallerArgumentExpression("value")] string name = "")
+    public void AppendFormatted(object? value, int alignment = 0, string? format = null, [CallerArgumentExpression(nameof(value))] string name = "")
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
     {
         var tb = TemplateBuilder.Value!;
@@ -144,7 +144,7 @@ public ref partial struct LogInterpolatedStringHandler
     /// This method is only meant for internal use by L.o.U.I.S. and should not be used directly.
     /// </summary>
 #pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters - We need CallerArgumentExpression here
-    public void AppendFormatted<T>(T? value, int alignment = 0, string? format = null, [CallerArgumentExpression("value")] string name = "")
+    public void AppendFormatted<T>(T? value, int alignment = 0, string? format = null, [CallerArgumentExpression(nameof(value))] string name = "")
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
         where T : struct
         => AppendFormatted(value.HasValue ? value.GetValueOrDefault() : null, alignment, format, name);

--- a/src/Louis.Logging/LogInterpolatedStringHandler.cs
+++ b/src/Louis.Logging/LogInterpolatedStringHandler.cs
@@ -147,6 +147,11 @@ public ref partial struct LogInterpolatedStringHandler
     public void AppendFormatted<T>(T? value, int alignment = 0, string? format = null, [CallerArgumentExpression(nameof(value))] string name = "")
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
         where T : struct
+
+        // DO NOT merge the conditional below!
+        // As in: => AppendFormatted(value, alignment, format, name);
+        // It will mess with overload resolution, triggering infinite recursion.
+        // ReSharper disable once MergeConditionalExpression
         => AppendFormatted(value.HasValue ? value.GetValueOrDefault() : null, alignment, format, name);
 
     internal (string Template, object?[] Arguments) GetDataAndClear()

--- a/src/Louis/Diagnostics/ExceptionExtensions.CausingExceptions.cs
+++ b/src/Louis/Diagnostics/ExceptionExtensions.CausingExceptions.cs
@@ -9,7 +9,7 @@ namespace Louis.Diagnostics;
 
 partial class ExceptionExtensions
 {
-    private class CausingExceptions : IEnumerable<Exception>
+    private sealed class CausingExceptions : IEnumerable<Exception>
     {
         private readonly Exception _exception;
 

--- a/tests/LoggingTests/Regressions/Issue24.cs
+++ b/tests/LoggingTests/Regressions/Issue24.cs
@@ -3,7 +3,7 @@
 
 namespace Regressions;
 
-public class Issue24
+public sealed class Issue24
 {
     private const string GotchaMessage = "Gotcha!";
 

--- a/tests/LoggingTests/Regressions/Issue24.cs
+++ b/tests/LoggingTests/Regressions/Issue24.cs
@@ -109,5 +109,36 @@ public sealed class Issue24
               .Should().NotThrow();
     }
 
-    private int Boom() => throw new InvalidOperationException(GotchaMessage);
+    // This is not related to the bug in Issue #24, but strictly related to the other tests in this class.
+    [Theory]
+    [InlineData(LogLevel.Trace)]
+    [InlineData(LogLevel.Debug)]
+    [InlineData(LogLevel.Information)]
+    [InlineData(LogLevel.Warning)]
+    [InlineData(LogLevel.Error)]
+    [InlineData(LogLevel.Critical)]
+    public void Log_WhenLevelEnabled_EvaluatesInterpolations(LogLevel logLevel)
+    {
+        var logger = new TestLogger(logLevel, enable: true);
+        _ = logger.Invoking(l => l.Log(logLevel, $"Let's go {Boom()}!"))
+                  .Should().Throw<InvalidOperationException>()
+                  .WithMessage(GotchaMessage);
+    }
+
+    // This is not related to the bug in Issue #24, but strictly related to the other tests in this class.
+    [Theory]
+    [InlineData(LogLevel.Trace)]
+    [InlineData(LogLevel.Debug)]
+    [InlineData(LogLevel.Information)]
+    [InlineData(LogLevel.Warning)]
+    [InlineData(LogLevel.Error)]
+    [InlineData(LogLevel.Critical)]
+    public void Log_WhenLevelNotEnabled_DoesNotEvaluateInterpolations(LogLevel logLevel)
+    {
+        var logger = new TestLogger(logLevel, enable: false);
+        _ = logger.Invoking(l => l.Log(logLevel, $"Let's go {Boom()}!"))
+                  .Should().NotThrow();
+    }
+
+    private static int Boom() => throw new InvalidOperationException(GotchaMessage);
 }


### PR DESCRIPTION
## Proposed changes

- Make class Issue24 sealed.
- Make class ExceptionExtensions.CausingExceptions sealed.
- Add interpolation evaluation tests for the Log extension method. Not related to issue #24, but strictly related to its regression tests.
- Add a comment explaining why a conditional is the way it is. Optimizing it would cause infinite recursion, so now hopefully nobody will get too smart for their own good.
- Remove `readonly` attribute from LogInterpolationStringHandler subclasses, because it caused unnecessary copying before every call to a method. ReSharper seems to agree with this BTW.
- Use nameof in argument attribute parameters. Some code written before .NET 7 RTM still used string constants in `CallerArgumentExpression` attributes.

### Checklist of related issues / discussions

No related issues.

## Types of changes

This pull request introduces the following types of changes:

<!-- Put an `x` in the boxes that apply. -->

- [x] Bug fix <!-- This includes changes to tests and XML documentation as applicable. -->
- [ ] New feature <!-- This includes changes to tests and XML documentation as applicable. -->
- [ ] Test addition / update (no changes to non-test code)
- [ ] Refactor (no changes in public API syntax or semantics)
- [x] Performance improvement (no changes in public API syntax or semantics)
- [ ] Documentation (`docs` directory) update
- [ ] Dependency addition / update
- [ ] Changes to the build scripts
- [ ] Changes to CI (workflows, bot / app configurations)
- [ ] Changes to repository files (`.gitattributes`, `.gitignore`)
- [ ] Other

### Breaking changes

This pull request introduces breaking changes:

<!-- Put an `x` in the box that applies. -->

- [ ] Yes
- [x] No

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- **For all types of changes:**
  - [x] I have read the [Code of Conduct](https://github.com/Tenacom/.github/blob/main/CODE_OF_CONDUCT.md) and agree to be bound by it
  - [x] I have read the [Contributor Guide](https://github.com/Tenacom/.github/blob/main/CONTRIBUTING.md) and agree to follow it
- **For code changes only:**
  - [x] The project builds on my machine, via the provided build script, _with zero warnings_
  - [ ] ~~I have added tests that prove my feature works / my fix is effective~~ _(not applicable)_
  - [ ] ~~I have added / modified XML documentation according to changes in code~~ _(not applicable)_
  - [ ] ~~I have checked that all the links I added or modified in XML documentation point to their intended destination~~ _(not applicable)_
- **For documentation changes (`docs` directory) only:**
  - [ ] I have built and tested documentation locally
  - [ ] I have checked that all the links I added or modified point to their intended destination
