### PR TITLE
Add more fluent extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### New features
 
+- Added method `Louis.Fluency.FluentExtensions.IfNotNull`, which calls an action on an object and an additional argument only if the latter is not `null`.
+
 ### Changes to existing features
 
 ### Bugs fixed in this release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### New features
 
 - Added method `Louis.Fluency.FluentExtensions.IfNotNull`, which calls an action on an object and an additional argument only if the latter is not `null`.
+- Added overloads to `Louis.Fluency.FluentExtensions` that take simple `Action`s instead of `FluentAction`s as arguments.
 
 ### Changes to existing features
 

--- a/src/Louis/Fluency/FluentExtensions-ForEach.cs
+++ b/src/Louis/Fluency/FluentExtensions-ForEach.cs
@@ -27,6 +27,7 @@ partial class FluentExtensions
     /// <para>- or -</para>
     /// <para><paramref name="sequence"/> is <see langword="null"/>.</para>
     /// </exception>
+    /// <seealso cref="ForEach{T,TElement}(T,IEnumerable{TElement},Action{T,TElement})"/>
     /// <seealso cref="ForEach{T,TElement}(T,ReadOnlySpan{TElement},FluentAction{T,TElement})"/>
     public static T ForEach<T, TElement>(this T @this, IEnumerable<TElement> sequence, FluentAction<T, TElement> action)
     {
@@ -37,6 +38,39 @@ partial class FluentExtensions
         foreach (var item in sequence)
         {
             @this = action(@this, item);
+        }
+
+        return @this;
+    }
+
+    /// <summary>
+    /// Performs a specified action on an object and each element of a sequence,
+    /// then returns the object.
+    /// </summary>
+    /// <typeparam name="T">The type of the object.</typeparam>
+    /// <typeparam name="TElement">The type of each element of the sequence.</typeparam>
+    /// <param name="this">The object on which this method was called.</param>
+    /// <param name="sequence">The sequence of elements.</param>
+    /// <param name="action">The action to perform.</param>
+    /// <returns>The result of the last call to <paramref name="action"/>.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <para><paramref name="this"/> is <see langword="null"/>.</para>
+    /// <para>- or -</para>
+    /// <para><paramref name="action"/> is <see langword="null"/>.</para>
+    /// <para>- or -</para>
+    /// <para><paramref name="sequence"/> is <see langword="null"/>.</para>
+    /// </exception>
+    /// <seealso cref="ForEach{T,TElement}(T,IEnumerable{TElement},FluentAction{T,TElement})"/>
+    /// <seealso cref="ForEach{T,TElement}(T,ReadOnlySpan{TElement},Action{T,TElement})"/>
+    public static T ForEach<T, TElement>(this T @this, IEnumerable<TElement> sequence, Action<T, TElement> action)
+    {
+        Guard.IsNotNull(@this);
+        Guard.IsNotNull(action);
+        Guard.IsNotNull(sequence);
+
+        foreach (var item in sequence)
+        {
+            action(@this, item);
         }
 
         return @this;
@@ -65,6 +99,7 @@ partial class FluentExtensions
     /// <para>- or -</para>
     /// <para><paramref name="sequence"/> is <see langword="null"/>.</para>
     /// </exception>
+    /// <seealso cref="ForEach{T,TElement}(T,IEnumerable{TElement},Action{T,TElement,int})"/>
     /// <seealso cref="ForEach{T,TElement}(T,ReadOnlySpan{TElement},FluentAction{T,TElement,int})"/>
     public static T ForEach<T, TElement>(this T @this, IEnumerable<TElement> sequence, FluentAction<T, TElement, int> action)
     {
@@ -76,6 +111,45 @@ partial class FluentExtensions
         foreach (var item in sequence)
         {
             @this = action(@this, item, index++);
+        }
+
+        return @this;
+    }
+
+    /// <summary>
+    /// Performs a specified action on an object and each element of a sequence,
+    /// then returns the object.
+    /// </summary>
+    /// <typeparam name="T">The type of the object.</typeparam>
+    /// <typeparam name="TElement">The type of each element of the sequence.</typeparam>
+    /// <param name="this">The object on which this method was called.</param>
+    /// <param name="sequence">The sequence of elements.</param>
+    /// <param name="action">The action to perform.</param>
+    /// <returns>The result of the last call to <paramref name="action"/>.</returns>
+    /// <remarks>
+    /// <para>This method is essentially the same as <see cref="ForEach{T,TElement}(T,IEnumerable{TElement},FluentAction{T,TElement})"/>,
+    /// but it also passes an index to <paramref name="action"/>. The passed index is 0 for the first call and is incremented by 1
+    /// for each subsequent call.</para>
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">
+    /// <para><paramref name="this"/> is <see langword="null"/>.</para>
+    /// <para>- or -</para>
+    /// <para><paramref name="action"/> is <see langword="null"/>.</para>
+    /// <para>- or -</para>
+    /// <para><paramref name="sequence"/> is <see langword="null"/>.</para>
+    /// </exception>
+    /// <seealso cref="ForEach{T,TElement}(T,IEnumerable{TElement},FluentAction{T,TElement,int})"/>
+    /// <seealso cref="ForEach{T,TElement}(T,ReadOnlySpan{TElement},Action{T,TElement,int})"/>
+    public static T ForEach<T, TElement>(this T @this, IEnumerable<TElement> sequence, Action<T, TElement, int> action)
+    {
+        Guard.IsNotNull(@this);
+        Guard.IsNotNull(action);
+        Guard.IsNotNull(sequence);
+
+        var index = 0;
+        foreach (var item in sequence)
+        {
+            action(@this, item, index++);
         }
 
         return @this;
@@ -97,6 +171,7 @@ partial class FluentExtensions
     /// <para>- or -</para>
     /// <para><paramref name="action"/> is <see langword="null"/>.</para>
     /// </exception>
+    /// <seealso cref="ForEach{T,TElement}(T,ReadOnlySpan{TElement},Action{T,TElement})"/>
     /// <seealso cref="ForEach{T,TElement}(T,IEnumerable{TElement},FluentAction{T,TElement})"/>
     public static T ForEach<T, TElement>(this T @this, ReadOnlySpan<TElement> span, FluentAction<T, TElement> action)
     {
@@ -106,6 +181,36 @@ partial class FluentExtensions
         foreach (var item in span)
         {
             @this = action(@this, item);
+        }
+
+        return @this;
+    }
+
+    /// <summary>
+    /// Performs a specified action on an object and each element of a span,
+    /// then returns the object.
+    /// </summary>
+    /// <typeparam name="T">The type of the object.</typeparam>
+    /// <typeparam name="TElement">The type of each element of the span.</typeparam>
+    /// <param name="this">The object on which this method was called.</param>
+    /// <param name="span">The span of elements.</param>
+    /// <param name="action">The action to perform.</param>
+    /// <returns>The result of the last call to <paramref name="action"/>.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <para><paramref name="this"/> is <see langword="null"/>.</para>
+    /// <para>- or -</para>
+    /// <para><paramref name="action"/> is <see langword="null"/>.</para>
+    /// </exception>
+    /// <seealso cref="ForEach{T,TElement}(T,ReadOnlySpan{TElement},FluentAction{T,TElement})"/>
+    /// <seealso cref="ForEach{T,TElement}(T,IEnumerable{TElement},Action{T,TElement})"/>
+    public static T ForEach<T, TElement>(this T @this, ReadOnlySpan<TElement> span, Action<T, TElement> action)
+    {
+        Guard.IsNotNull(@this);
+        Guard.IsNotNull(action);
+
+        foreach (var item in span)
+        {
+            action(@this, item);
         }
 
         return @this;
@@ -131,6 +236,7 @@ partial class FluentExtensions
     /// <para>- or -</para>
     /// <para><paramref name="action"/> is <see langword="null"/>.</para>
     /// </exception>
+    /// <seealso cref="ForEach{T,TElement}(T,ReadOnlySpan{TElement},Action{T,TElement,int})"/>
     /// <seealso cref="ForEach{T,TElement}(T,IEnumerable{TElement},FluentAction{T,TElement,int})"/>
     public static T ForEach<T, TElement>(this T @this, ReadOnlySpan<TElement> span, FluentAction<T, TElement, int> action)
     {
@@ -140,6 +246,41 @@ partial class FluentExtensions
         for (var i = 0; i < span.Length; i++)
         {
             @this = action(@this, span[i], i);
+        }
+
+        return @this;
+    }
+
+    /// <summary>
+    /// Performs a specified action on an object and each element of a span,
+    /// each time taking the result of the action as the object to pass together with the next element,
+    /// then returns the result of the last action.
+    /// </summary>
+    /// <typeparam name="T">The type of the object.</typeparam>
+    /// <typeparam name="TElement">The type of each element of the span.</typeparam>
+    /// <param name="this">The object on which this method was called.</param>
+    /// <param name="span">The span of elements.</param>
+    /// <param name="action">The action to perform.</param>
+    /// <returns>The result of the last call to <paramref name="action"/>.</returns>
+    /// <remarks>
+    /// <para>This method is essentially the same as <see cref="ForEach{T,TElement}(T,ReadOnlySpan{TElement},FluentAction{T,TElement})"/>,
+    /// but it also passes the index of each element to <paramref name="action"/>.</para>
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">
+    /// <para><paramref name="this"/> is <see langword="null"/>.</para>
+    /// <para>- or -</para>
+    /// <para><paramref name="action"/> is <see langword="null"/>.</para>
+    /// </exception>
+    /// <seealso cref="ForEach{T,TElement}(T,ReadOnlySpan{TElement},FluentAction{T,TElement,int})"/>
+    /// <seealso cref="ForEach{T,TElement}(T,IEnumerable{TElement},Action{T,TElement,int})"/>
+    public static T ForEach<T, TElement>(this T @this, ReadOnlySpan<TElement> span, Action<T, TElement, int> action)
+    {
+        Guard.IsNotNull(@this);
+        Guard.IsNotNull(action);
+
+        for (var i = 0; i < span.Length; i++)
+        {
+            action(@this, span[i], i);
         }
 
         return @this;

--- a/src/Louis/Fluency/FluentExtensions-If.cs
+++ b/src/Louis/Fluency/FluentExtensions-If.cs
@@ -21,11 +21,39 @@ partial class FluentExtensions
     /// <para>- or -</para>
     /// <para><paramref name="then"/> is <see langword="null"/>.</para>
     /// </exception>
+    /// <seealso cref="If{T}(T,bool,Action{T})"/>
     public static T If<T>(this T @this, bool condition, FluentAction<T> then)
     {
         Guard.IsNotNull(@this);
         Guard.IsNotNull(then);
 
         return condition ? then(@this) : @this;
+    }
+
+    /// <summary>
+    /// Invokes an action on an object if a condition is verified, then returns the same object.
+    /// </summary>
+    /// <typeparam name="T">The type of the object.</typeparam>
+    /// <param name="this">The object on which this method was called.</param>
+    /// <param name="condition">The condition to test.</param>
+    /// <param name="then">The action to perform on <paramref name="this"/> if <paramref name="condition"/> is <see langword="true"/>.</param>
+    /// <returns>A reference to <paramref name="this"/> after <paramref name="then"/>, if called, returns.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <para><paramref name="this"/> is <see langword="null"/>.</para>
+    /// <para>- or -</para>
+    /// <para><paramref name="then"/> is <see langword="null"/>.</para>
+    /// </exception>
+    /// <seealso cref="If{T}(T,bool,FluentAction{T})"/>
+    public static T If<T>(this T @this, bool condition, Action<T> then)
+    {
+        Guard.IsNotNull(@this);
+        Guard.IsNotNull(then);
+
+        if (condition)
+        {
+            then(@this);
+        }
+
+        return @this;
     }
 }

--- a/src/Louis/Fluency/FluentExtensions-IfElse.cs
+++ b/src/Louis/Fluency/FluentExtensions-IfElse.cs
@@ -32,4 +32,38 @@ partial class FluentExtensions
 
         return condition ? then(@this) : @else(@this);
     }
+
+    /// <summary>
+    /// Invokes one of two actions on an object according to a boolean condition, then returns the same object.
+    /// </summary>
+    /// <typeparam name="T">The type of the object.</typeparam>
+    /// <param name="this">The object on which this method was called.</param>
+    /// <param name="condition">The condition to test.</param>
+    /// <param name="then">The action to perform on <paramref name="this"/> if <paramref name="condition"/> is <see langword="true"/>.</param>
+    /// <param name="else">The action to perform on <paramref name="this"/> if <paramref name="condition"/> is <see langword="false"/>.</param>
+    /// <returns>A reference to <paramref name="this"/> after either <paramref name="then"/> or <paramref name="else"/> returns.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <para><paramref name="this"/> is <see langword="null"/>.</para>
+    /// <para>- or -</para>
+    /// <para><paramref name="then"/> is <see langword="null"/>.</para>
+    /// <para>- or -</para>
+    /// <para><paramref name="else"/> is <see langword="null"/>.</para>
+    /// </exception>
+    public static T IfElse<T>(this T @this, bool condition, Action<T> then, Action<T> @else)
+    {
+        Guard.IsNotNull(@this);
+        Guard.IsNotNull(then);
+        Guard.IsNotNull(@else);
+
+        if (condition)
+        {
+            then(@this);
+        }
+        else
+        {
+            @else(@this);
+        }
+
+        return @this;
+    }
 }

--- a/src/Louis/Fluency/FluentExtensions-IfNotNull.cs
+++ b/src/Louis/Fluency/FluentExtensions-IfNotNull.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Tenacom and contributors. Licensed under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using CommunityToolkit.Diagnostics;
+
+namespace Louis.Fluency;
+
+partial class FluentExtensions
+{
+    /// <summary>
+    /// Invokes an action on an object if a reference is not <see langword="null"/>, then returns the same object.
+    /// </summary>
+    /// <typeparam name="T">The type of the object.</typeparam>
+    /// <typeparam name="T1">The type of the additional argument to pass to <paramref name="then"/>.</typeparam>
+    /// <param name="this">The object on which this method was called.</param>
+    /// <param name="arg">The additional argument to pass to <paramref name="then"/>.</param>
+    /// <param name="then">The action to perform on <paramref name="this"/> and <paramref name="arg"/>if <paramref name="arg "/> is not <see langword="null"/>.</param>
+    /// <returns>A reference to <paramref name="this"/> after <paramref name="then"/>, if called, returns.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <para><paramref name="this"/> is <see langword="null"/>.</para>
+    /// <para>- or -</para>
+    /// <para><paramref name="then"/> is <see langword="null"/>.</para>
+    /// </exception>
+    public static T IfNotNull<T, T1>(this T @this, T1? arg, FluentAction<T, T1> then)
+        where T1 : notnull
+    {
+        Guard.IsNotNull(@this);
+        Guard.IsNotNull(then);
+
+        return arg != null ? then(@this, arg) : @this;
+    }
+}

--- a/src/Louis/Fluency/FluentExtensions-IfNotNull.cs
+++ b/src/Louis/Fluency/FluentExtensions-IfNotNull.cs
@@ -30,4 +30,32 @@ partial class FluentExtensions
 
         return arg != null ? then(@this, arg) : @this;
     }
+
+    /// <summary>
+    /// Invokes an action on an object if a reference is not <see langword="null"/>, then returns the same object.
+    /// </summary>
+    /// <typeparam name="T">The type of the object.</typeparam>
+    /// <typeparam name="T1">The type of the additional argument to pass to <paramref name="then"/>.</typeparam>
+    /// <param name="this">The object on which this method was called.</param>
+    /// <param name="arg">The additional argument to pass to <paramref name="then"/>.</param>
+    /// <param name="then">The action to perform on <paramref name="this"/> and <paramref name="arg"/>if <paramref name="arg "/> is not <see langword="null"/>.</param>
+    /// <returns>A reference to <paramref name="this"/> after <paramref name="then"/>, if called, returns.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <para><paramref name="this"/> is <see langword="null"/>.</para>
+    /// <para>- or -</para>
+    /// <para><paramref name="then"/> is <see langword="null"/>.</para>
+    /// </exception>
+    public static T IfNotNull<T, T1>(this T @this, T1? arg, Action<T, T1> then)
+        where T1 : notnull
+    {
+        Guard.IsNotNull(@this);
+        Guard.IsNotNull(then);
+
+        if (arg != null)
+        {
+            then(@this, arg);
+        }
+
+        return @this;
+    }
 }

--- a/src/Louis/Fluency/FluentExtensions-Switch.cs
+++ b/src/Louis/Fluency/FluentExtensions-Switch.cs
@@ -41,6 +41,32 @@ partial class FluentExtensions
     /// <typeparam name="TValue">The type of the value being compared.</typeparam>
     /// <param name="this">The object on which this method was called.</param>
     /// <param name="value">The value to compare.</param>
+    /// <param name="cases">
+    /// <para>An array of pairs, where each element consists of a value to compare against <paramref name="value"/>
+    /// and an optional action to perform on <paramref name="this"/> if they are equal.</para>
+    /// <para>If the action is <see langword="null"/>, no action is performed if the value is equal to <paramref name="value"/>;
+    /// instead, the method returns immediately.</para>
+    /// </param>
+    /// <returns>A reference to <paramref name="this"/> after one of the actions in <paramref name="cases"/>, if any, returns.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <para><paramref name="this"/> is <see langword="null"/>.</para>
+    /// <para>- or -</para>
+    /// <para><paramref name="cases"/> is <see langword="null"/>.</para>
+    /// </exception>
+    /// <remarks>
+    /// <para>If <paramref name="value"/> is not equal to any of the values in <paramref name="cases"/>, this method returns immediately.</para>
+    /// </remarks>
+    public static T Switch<T, TValue>(this T @this, TValue value, params (TValue Comparand, Action<T>? Action)[] cases)
+        where TValue : IEquatable<TValue>
+        => Switch(@this, value, null, cases);
+
+    /// <summary>
+    /// Selects an action to invoke on an object by comparing a given value against a list of comparands, then returns the object.
+    /// </summary>
+    /// <typeparam name="T">The type of the object.</typeparam>
+    /// <typeparam name="TValue">The type of the value being compared.</typeparam>
+    /// <param name="this">The object on which this method was called.</param>
+    /// <param name="value">The value to compare.</param>
     /// <param name="default">
     /// <para>An optional action to perform on <paramref name="this"/> if <paramref name="value"/> is not equal
     /// to any of the values in <paramref name="cases"/>.</para>
@@ -74,5 +100,49 @@ partial class FluentExtensions
         }
 
         return @default == null ? @this : @default(@this);
+    }
+
+    /// <summary>
+    /// Selects an action to invoke on an object by comparing a given value against a list of comparands, then returns the object.
+    /// </summary>
+    /// <typeparam name="T">The type of the object.</typeparam>
+    /// <typeparam name="TValue">The type of the value being compared.</typeparam>
+    /// <param name="this">The object on which this method was called.</param>
+    /// <param name="value">The value to compare.</param>
+    /// <param name="default">
+    /// <para>An optional action to perform on <paramref name="this"/> if <paramref name="value"/> is not equal
+    /// to any of the values in <paramref name="cases"/>.</para>
+    /// <para>If this parameter is <see langword="null"/> and <paramref name="value"/> is not equal
+    /// to any of the values in <paramref name="cases"/>, this method returns immediately.</para>
+    /// </param>
+    /// <param name="cases">
+    /// <para>An array of pairs, where each element consists of a value to compare against <paramref name="value"/>
+    /// and an optional action to perform on <paramref name="this"/> if they are equal.</para>
+    /// <para>If the action is <see langword="null"/>, no action is performed if the value is equal to <paramref name="value"/>;
+    /// instead, the method returns immediately.</para>
+    /// </param>
+    /// <returns>A reference to <paramref name="this"/> after one of the actions in <paramref name="cases"/>, if any, returns.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <para><paramref name="this"/> is <see langword="null"/>.</para>
+    /// <para>- or -</para>
+    /// <para><paramref name="cases"/> is <see langword="null"/>.</para>
+    /// </exception>
+    public static T Switch<T, TValue>(this T @this, TValue value, FluentAction<T>? @default, params (TValue Comparand, Action<T>? Action)[] cases)
+        where TValue : IEquatable<TValue>
+    {
+        Guard.IsNotNull(@this);
+        Guard.IsNotNull(cases);
+
+        foreach (var (comparand, action) in cases)
+        {
+            if (value.Equals(comparand))
+            {
+                action?.Invoke(@this);
+                return @this;
+            }
+        }
+
+        @default?.Invoke(@this);
+        return @this;
     }
 }

--- a/src/Louis/PublicAPI.Unshipped.txt
+++ b/src/Louis/PublicAPI.Unshipped.txt
@@ -74,14 +74,23 @@ static Louis.DisposingUtility.DisposeAsync(object? obj) -> System.Threading.Task
 static Louis.DisposingUtility.DisposeAsync(params object?[]! items) -> System.Threading.Tasks.ValueTask
 static Louis.Fluency.FluentExtensions.ForEach<T, TElement>(this T this, System.Collections.Generic.IEnumerable<TElement>! sequence, Louis.Fluency.FluentAction<T, TElement, int>! action) -> T
 static Louis.Fluency.FluentExtensions.ForEach<T, TElement>(this T this, System.Collections.Generic.IEnumerable<TElement>! sequence, Louis.Fluency.FluentAction<T, TElement>! action) -> T
+static Louis.Fluency.FluentExtensions.ForEach<T, TElement>(this T this, System.Collections.Generic.IEnumerable<TElement>! sequence, System.Action<T, TElement, int>! action) -> T
+static Louis.Fluency.FluentExtensions.ForEach<T, TElement>(this T this, System.Collections.Generic.IEnumerable<TElement>! sequence, System.Action<T, TElement>! action) -> T
 static Louis.Fluency.FluentExtensions.ForEach<T, TElement>(this T this, System.ReadOnlySpan<TElement> span, Louis.Fluency.FluentAction<T, TElement, int>! action) -> T
 static Louis.Fluency.FluentExtensions.ForEach<T, TElement>(this T this, System.ReadOnlySpan<TElement> span, Louis.Fluency.FluentAction<T, TElement>! action) -> T
+static Louis.Fluency.FluentExtensions.ForEach<T, TElement>(this T this, System.ReadOnlySpan<TElement> span, System.Action<T, TElement, int>! action) -> T
+static Louis.Fluency.FluentExtensions.ForEach<T, TElement>(this T this, System.ReadOnlySpan<TElement> span, System.Action<T, TElement>! action) -> T
 static Louis.Fluency.FluentExtensions.If<T>(this T this, bool condition, Louis.Fluency.FluentAction<T>! then) -> T
+static Louis.Fluency.FluentExtensions.If<T>(this T this, bool condition, System.Action<T>! then) -> T
 static Louis.Fluency.FluentExtensions.IfElse<T>(this T this, bool condition, Louis.Fluency.FluentAction<T>! then, Louis.Fluency.FluentAction<T>! else) -> T
+static Louis.Fluency.FluentExtensions.IfElse<T>(this T this, bool condition, System.Action<T>! then, System.Action<T>! else) -> T
 static Louis.Fluency.FluentExtensions.IfNotNull<T, T1>(this T this, T1? arg, Louis.Fluency.FluentAction<T, T1>! then) -> T
+static Louis.Fluency.FluentExtensions.IfNotNull<T, T1>(this T this, T1? arg, System.Action<T, T1>! then) -> T
 static Louis.Fluency.FluentExtensions.Invoke<T>(this T this, System.Action<T>! action) -> T
 static Louis.Fluency.FluentExtensions.Switch<T, TValue>(this T this, TValue value, Louis.Fluency.FluentAction<T>? default, params (TValue Comparand, Louis.Fluency.FluentAction<T>? Action)[]! cases) -> T
+static Louis.Fluency.FluentExtensions.Switch<T, TValue>(this T this, TValue value, Louis.Fluency.FluentAction<T>? default, params (TValue Comparand, System.Action<T>? Action)[]! cases) -> T
 static Louis.Fluency.FluentExtensions.Switch<T, TValue>(this T this, TValue value, params (TValue Comparand, Louis.Fluency.FluentAction<T>? Action)[]! cases) -> T
+static Louis.Fluency.FluentExtensions.Switch<T, TValue>(this T this, TValue value, params (TValue Comparand, System.Action<T>? Action)[]! cases) -> T
 static Louis.RangeCheck.Clamp<T>(T value, T min, T max) -> T
 static Louis.RangeCheck.Clamp<T>(T value, T min, T max, System.Collections.Generic.IComparer<T>! comparer) -> T
 static Louis.RangeCheck.ClampOrNull<T>(T? value, T min, T max) -> T?

--- a/src/Louis/PublicAPI.Unshipped.txt
+++ b/src/Louis/PublicAPI.Unshipped.txt
@@ -78,6 +78,7 @@ static Louis.Fluency.FluentExtensions.ForEach<T, TElement>(this T this, System.R
 static Louis.Fluency.FluentExtensions.ForEach<T, TElement>(this T this, System.ReadOnlySpan<TElement> span, Louis.Fluency.FluentAction<T, TElement>! action) -> T
 static Louis.Fluency.FluentExtensions.If<T>(this T this, bool condition, Louis.Fluency.FluentAction<T>! then) -> T
 static Louis.Fluency.FluentExtensions.IfElse<T>(this T this, bool condition, Louis.Fluency.FluentAction<T>! then, Louis.Fluency.FluentAction<T>! else) -> T
+static Louis.Fluency.FluentExtensions.IfNotNull<T, T1>(this T this, T1? arg, Louis.Fluency.FluentAction<T, T1>! then) -> T
 static Louis.Fluency.FluentExtensions.Invoke<T>(this T this, System.Action<T>! action) -> T
 static Louis.Fluency.FluentExtensions.Switch<T, TValue>(this T this, TValue value, Louis.Fluency.FluentAction<T>? default, params (TValue Comparand, Louis.Fluency.FluentAction<T>? Action)[]! cases) -> T
 static Louis.Fluency.FluentExtensions.Switch<T, TValue>(this T this, TValue value, params (TValue Comparand, Louis.Fluency.FluentAction<T>? Action)[]! cases) -> T


### PR DESCRIPTION
## Proposed changes

Add the following to `Louis.Fluency.FluentExtensions`:

- An `IfNotNull` extension method to call a specified action only if an argument is not `null`.  
For example:
```c#
obj = obj.IfNotNull(arg, static (x, a) => x.DoSomethingWith(a));
```
This avoids the nullability warning raised by this use of `FluentExtensions.If`:
```c#
obj = obj.If(arg != null, x => x.DoSomethingWith(arg));
```
- method overloads that work with simple `Action` delegates instead of `FluentAction`s.

### Checklist of related issues / discussions

(n/a)

## Types of changes

This pull request introduces the following types of changes:

- [ ] Bug fix <!-- This includes changes to tests and XML documentation as applicable. -->
- [x] New feature <!-- This includes changes to tests and XML documentation as applicable. -->
- [ ] Test addition / update (no changes to non-test code)
- [ ] Refactor (no changes in public API syntax or semantics)
- [ ] Performance improvement (no changes in public API syntax or semantics)
- [ ] Documentation (`docs` directory) update
- [ ] Dependency addition / update
- [ ] Changes to the build scripts
- [ ] Changes to CI (workflows, bot / app configurations)
- [ ] Changes to repository files (`.gitattributes`, `.gitignore`)
- [ ] Other

### Breaking changes

This pull request introduces breaking changes:

- [ ] Yes
- [x] No

## Checklist

- **For all types of changes:**
  - [x] I have read the [Code of Conduct](https://github.com/Tenacom/.github/blob/main/CODE_OF_CONDUCT.md) and agree to be bound by it
  - [x] I have read the [Contributor Guide](https://github.com/Tenacom/.github/blob/main/CONTRIBUTING.md) and agree to follow it
- **For code changes only:**
  - [x] The project builds on my machine, via the provided build script, _with zero warnings_
  - [ ] I have added tests that prove my feature works / my fix is effective
  - [x] I have added / modified XML documentation according to changes in code
  - [x] I have checked that all the links I added or modified in XML documentation point to their intended destination
- **For documentation changes (`docs` directory) only:**
  - [ ] I have built and tested documentation locally
  - [ ] I have checked that all the links I added or modified point to their intended destination
