### PR TITLE
Implement asynchronous background services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### New features
 
+- Added class `Louis.Threading.AsyncService`: a complete revamp of the old `AsyncWorker` class that was present in the very first alpha version of L.o.U.I.S., this class simplifies the implementation and use of long-running background tasks.
+- Added package `Louis.Hosting` with an `AsyncHostedService` class, that extends `AsyncService` with logging and implements the [`IHostedService`](https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.hosting.ihostedservice) interface for integration in ASP.NET applications, as well as any application based on the [`generic host`](https://learn.microsoft.com/en-us/dotnet/core/extensions/generic-host).
+
 ### Changes to existing features
 
 ### Bugs fixed in this release

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,6 +14,7 @@
   <ItemGroup>
     <PackageVersion Include="CommunityToolkit.Diagnostics" Version="8.2.0" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
     <PackageVersion Include="PolyKit" Version="2.0.30" />
     <PackageVersion Include="System.Memory" Version="4.5.5" />

--- a/Louis.sln
+++ b/Louis.sln
@@ -48,6 +48,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "- Dependencies", "- Depende
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LoggingTests", "tests\LoggingTests\LoggingTests.csproj", "{F6604E25-C15E-4108-AE40-4C209767C473}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Louis.Hosting", "src\Louis.Hosting\Louis.Hosting.csproj", "{1962DC3E-CA58-44E3-8186-7E42D8A9646E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -66,6 +68,10 @@ Global
 		{F6604E25-C15E-4108-AE40-4C209767C473}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F6604E25-C15E-4108-AE40-4C209767C473}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F6604E25-C15E-4108-AE40-4C209767C473}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1962DC3E-CA58-44E3-8186-7E42D8A9646E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1962DC3E-CA58-44E3-8186-7E42D8A9646E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1962DC3E-CA58-44E3-8186-7E42D8A9646E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1962DC3E-CA58-44E3-8186-7E42D8A9646E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -75,6 +81,7 @@ Global
 		{E9C789C3-E611-4BF1-BCEF-73F2F4BF13BB} = {75CB1268-E052-4A3F-8022-2C21C84D9B32}
 		{9673D9AD-53CE-4768-A74D-E8719A9D8FBD} = {AF6E590F-F997-442E-8F77-356C7E4DF275}
 		{F6604E25-C15E-4108-AE40-4C209767C473} = {0977BFBE-C5F3-4B90-9F9E-77061320CB9D}
+		{1962DC3E-CA58-44E3-8186-7E42D8A9646E} = {AF6E590F-F997-442E-8F77-356C7E4DF275}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {552BE595-AF8A-4BA2-9F45-D3CED6737ABB}

--- a/src/Louis.Hosting/AsyncHostedService.cs
+++ b/src/Louis.Hosting/AsyncHostedService.cs
@@ -1,0 +1,89 @@
+﻿// Copyright (c) Tenacom and contributors. Licensed under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using CommunityToolkit.Diagnostics;
+using Louis.Hosting.Internal;
+using Louis.Threading;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Louis.Hosting;
+
+/// <summary>
+/// Subclasses <see cref="AsyncService"/>, providing support for logging and implementing <see cref="IHostedService"/>.
+/// </summary>
+public abstract partial class AsyncHostedService : AsyncService, IHostedService
+{
+    private readonly ILogger _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AsyncHostedService"/> class.
+    /// </summary>
+    /// <param name="logger">An <see cref="ILogger"/> to use for logging.</param>
+    protected AsyncHostedService(ILogger logger)
+    {
+        Guard.IsNotNull(logger);
+        _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    async Task IHostedService.StartAsync(CancellationToken cancellationToken)
+    {
+        if (await StartAsync(cancellationToken))
+        {
+            return;
+        }
+
+        // If AsyncService.StartAsync returns false, then either the service was canceled, or SetupAsync faulted.
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowHelper.ThrowInvalidOperationException("Service start faulted.");
+    }
+
+    /// <inheritdoc/>
+    Task IHostedService.StopAsync(CancellationToken cancellationToken) => Task.WhenAny(StopAsync(), Task.Delay(Timeout.Infinite, cancellationToken));
+
+    /// <inheritdoc/>
+    [LoggerMessage(
+        eventId: EventIds.AsyncHostedService.StateChanged,
+        level: LogLevel.Trace,
+        message: "Service state {oldState} -> {newState}")]
+    protected sealed override partial void LogStateChanged(AsyncServiceState oldState, AsyncServiceState newState);
+
+    /// <inheritdoc/>
+    [LoggerMessage(
+        eventId: EventIds.AsyncHostedService.SetupCanceled,
+        level: LogLevel.Warning,
+        message: "Service execution was canceled during setup phase")]
+    protected sealed override partial void LogSetupCanceled();
+
+    /// <inheritdoc/>
+    [LoggerMessage(
+        eventId: EventIds.AsyncHostedService.SetupFailed,
+        level: LogLevel.Error,
+        message: "Service setup phase failed")]
+    protected sealed override partial void LogSetupFailed(Exception exception);
+
+    /// <inheritdoc/>
+    [LoggerMessage(
+        eventId: EventIds.AsyncHostedService.ExecuteCanceled,
+        level: LogLevel.Warning,
+        message: "Service execution was canceled")]
+    protected sealed override partial void LogExecuteCanceled();
+
+    /// <inheritdoc/>
+    [LoggerMessage(
+        eventId: EventIds.AsyncHostedService.ExecuteFailed,
+        level: LogLevel.Error,
+        message: "Service execution failed")]
+    protected sealed override partial void LogExecuteFailed(Exception exception);
+
+    /// <inheritdoc/>
+    [LoggerMessage(
+        eventId: EventIds.AsyncHostedService.TeardownFailed,
+        level: LogLevel.Error,
+        message: "Service teardown phase failed")]
+    protected sealed override partial void LogTeardownFailed(Exception exception);
+}

--- a/src/Louis.Hosting/AsyncHostedService.cs
+++ b/src/Louis.Hosting/AsyncHostedService.cs
@@ -86,4 +86,14 @@ public abstract partial class AsyncHostedService : AsyncService, IHostedService
         level: LogLevel.Error,
         message: "Service teardown phase failed")]
     protected sealed override partial void LogTeardownFailed(Exception exception);
+
+    /// <inheritdoc/>
+    protected sealed override void LogStopRequested(AsyncServiceState previousState, AsyncServiceState currentState, bool result)
+        => LogStopRequestedCore(previousState, result ? "running" : "not running");
+
+    [LoggerMessage(
+        eventId: EventIds.AsyncHostedService.StopRequested,
+        level: LogLevel.Information,
+        message: "Stop requested while service {running} ({previousState})")]
+    private partial void LogStopRequestedCore(AsyncServiceState previousState, string running);
 }

--- a/src/Louis.Hosting/Internal/EventIds.cs
+++ b/src/Louis.Hosting/Internal/EventIds.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Tenacom and contributors. Licensed under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Louis.Hosting.Internal;
+
+internal static class EventIds
+{
+    public static class AsyncHostedService
+    {
+        public const int StateChanged = 0;
+        public const int SetupCanceled = 1;
+        public const int SetupFailed = 2;
+        public const int ExecuteCanceled = 3;
+        public const int ExecuteFailed = 4;
+        public const int TeardownFailed = 5;
+    }
+}

--- a/src/Louis.Hosting/Internal/EventIds.cs
+++ b/src/Louis.Hosting/Internal/EventIds.cs
@@ -13,5 +13,6 @@ internal static class EventIds
         public const int ExecuteCanceled = 3;
         public const int ExecuteFailed = 4;
         public const int TeardownFailed = 5;
+        public const int StopRequested = 6;
     }
 }

--- a/src/Louis.Hosting/Louis.Hosting.csproj
+++ b/src/Louis.Hosting/Louis.Hosting.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Description>Integration of L.o.U.I.S. with Microsoft.Extensions.Hosting.</Description>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net462;net6.0;net7.0</TargetFrameworks>
+    <UseTfmSpecificPublicApiFiles>false</UseTfmSpecificPublicApiFiles>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Louis\Louis.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
+  </ItemGroup>
+
+</Project>

--- a/src/Louis.Hosting/Louis.Hosting.csproj
+++ b/src/Louis.Hosting/Louis.Hosting.csproj
@@ -11,7 +11,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="CommunityToolkit.Diagnostics" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
   </ItemGroup>
 
 </Project>

--- a/src/Louis.Hosting/NuGet-README.md
+++ b/src/Louis.Hosting/NuGet-README.md
@@ -1,0 +1,10 @@
+# ![L.o.U.I.S.](https://raw.githubusercontent.com/Tenacom/Louis/main/graphics/Readme.png)
+
+---
+
+L.o.U.I.S. (pronounced _LOO-iss_, just like the name Louis) is a collection of useful types commonly needed in the development of .NET libraries and applications.
+
+This package contains `Louis.Hosting.dll`, that integrates L.o.U.I.S. with Microsoft's hosting extensions.
+
+Want to know more? [Here's the complete README.](https://github.com/Tenacom/Louis#readme)
+

--- a/src/Louis.Hosting/PublicAPI.Shipped.txt
+++ b/src/Louis.Hosting/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Louis.Hosting/PublicAPI.Unshipped.txt
+++ b/src/Louis.Hosting/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Louis.Hosting/PublicAPI.Unshipped.txt
+++ b/src/Louis.Hosting/PublicAPI.Unshipped.txt
@@ -1,1 +1,9 @@
 #nullable enable
+Louis.Hosting.AsyncHostedService
+Louis.Hosting.AsyncHostedService.AsyncHostedService(Microsoft.Extensions.Logging.ILogger! logger) -> void
+override sealed Louis.Hosting.AsyncHostedService.LogExecuteCanceled() -> void
+override sealed Louis.Hosting.AsyncHostedService.LogExecuteFailed(System.Exception! exception) -> void
+override sealed Louis.Hosting.AsyncHostedService.LogSetupCanceled() -> void
+override sealed Louis.Hosting.AsyncHostedService.LogSetupFailed(System.Exception! exception) -> void
+override sealed Louis.Hosting.AsyncHostedService.LogStateChanged(Louis.Threading.AsyncServiceState oldState, Louis.Threading.AsyncServiceState newState) -> void
+override sealed Louis.Hosting.AsyncHostedService.LogTeardownFailed(System.Exception! exception) -> void

--- a/src/Louis.Hosting/PublicAPI.Unshipped.txt
+++ b/src/Louis.Hosting/PublicAPI.Unshipped.txt
@@ -6,4 +6,5 @@ override sealed Louis.Hosting.AsyncHostedService.LogExecuteFailed(System.Excepti
 override sealed Louis.Hosting.AsyncHostedService.LogSetupCanceled() -> void
 override sealed Louis.Hosting.AsyncHostedService.LogSetupFailed(System.Exception! exception) -> void
 override sealed Louis.Hosting.AsyncHostedService.LogStateChanged(Louis.Threading.AsyncServiceState oldState, Louis.Threading.AsyncServiceState newState) -> void
+override sealed Louis.Hosting.AsyncHostedService.LogStopRequested(Louis.Threading.AsyncServiceState previousState, Louis.Threading.AsyncServiceState currentState, bool result) -> void
 override sealed Louis.Hosting.AsyncHostedService.LogTeardownFailed(System.Exception! exception) -> void

--- a/src/Louis/PublicAPI.Unshipped.txt
+++ b/src/Louis/PublicAPI.Unshipped.txt
@@ -39,6 +39,7 @@ Louis.Threading.AsyncService
 Louis.Threading.AsyncService.AsyncService() -> void
 Louis.Threading.AsyncService.Dispose() -> void
 Louis.Threading.AsyncService.DisposeAsync() -> System.Threading.Tasks.ValueTask
+Louis.Threading.AsyncService.DoneToken.get -> System.Threading.CancellationToken
 Louis.Threading.AsyncService.RunAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 Louis.Threading.AsyncService.Start(System.Threading.CancellationToken cancellationToken) -> void
 Louis.Threading.AsyncService.StartAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<bool>!

--- a/src/Louis/PublicAPI.Unshipped.txt
+++ b/src/Louis/PublicAPI.Unshipped.txt
@@ -189,5 +189,11 @@ static Louis.Threading.ValueTaskUtility.WhenAll(params System.Threading.Tasks.Va
 static Louis.Threading.ValueTaskUtility.WhenAll(System.Collections.Generic.IEnumerable<System.Threading.Tasks.ValueTask>! valueTasks) -> System.Threading.Tasks.ValueTask
 static readonly Louis.Text.Utf8Utility.Utf8NoBomEncoding -> System.Text.Encoding!
 virtual Louis.Threading.AsyncService.DisposeResourcesAsync() -> System.Threading.Tasks.ValueTask
+virtual Louis.Threading.AsyncService.OnExecuteCanceled() -> void
+virtual Louis.Threading.AsyncService.OnExecuteFailed(System.Exception! exception) -> void
+virtual Louis.Threading.AsyncService.OnSetupCanceled() -> void
+virtual Louis.Threading.AsyncService.OnSetupFailed(System.Exception! exception) -> void
+virtual Louis.Threading.AsyncService.OnStateChanged(Louis.Threading.AsyncServiceState oldState, Louis.Threading.AsyncServiceState newState) -> void
+virtual Louis.Threading.AsyncService.OnTeardownFailed(System.Exception! exception) -> void
 virtual Louis.Threading.AsyncService.SetupAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask
 virtual Louis.Threading.AsyncService.TeardownAsync() -> System.Threading.Tasks.ValueTask

--- a/src/Louis/PublicAPI.Unshipped.txt
+++ b/src/Louis/PublicAPI.Unshipped.txt
@@ -194,6 +194,7 @@ virtual Louis.Threading.AsyncService.LogExecuteFailed(System.Exception! exceptio
 virtual Louis.Threading.AsyncService.LogSetupCanceled() -> void
 virtual Louis.Threading.AsyncService.LogSetupFailed(System.Exception! exception) -> void
 virtual Louis.Threading.AsyncService.LogStateChanged(Louis.Threading.AsyncServiceState oldState, Louis.Threading.AsyncServiceState newState) -> void
+virtual Louis.Threading.AsyncService.LogStopRequested(Louis.Threading.AsyncServiceState previousState, Louis.Threading.AsyncServiceState currentState, bool result) -> void
 virtual Louis.Threading.AsyncService.LogTeardownFailed(System.Exception! exception) -> void
 virtual Louis.Threading.AsyncService.SetupAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask
 virtual Louis.Threading.AsyncService.TeardownAsync() -> System.Threading.Tasks.ValueTask

--- a/src/Louis/PublicAPI.Unshipped.txt
+++ b/src/Louis/PublicAPI.Unshipped.txt
@@ -1,4 +1,7 @@
 #nullable enable
+abstract Louis.Threading.AsyncService.OnStartServiceAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask
+abstract Louis.Threading.AsyncService.OnStopServiceAsync() -> System.Threading.Tasks.ValueTask
+abstract Louis.Threading.AsyncService.RunServiceAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 const Louis.Diagnostics.ExceptionHelper.NullText = "<null>" -> string!
 const Louis.Diagnostics.ExceptionHelper.ToStringEmptyText = "<empty!>" -> string!
 const Louis.Diagnostics.ExceptionHelper.ToStringNullText = "<null!>" -> string!
@@ -34,6 +37,24 @@ Louis.Text.StringLiteralKind.Quoted = 0 -> Louis.Text.StringLiteralKind
 Louis.Text.StringLiteralKind.Verbatim = 1 -> Louis.Text.StringLiteralKind
 Louis.Text.UnicodeCharacterUtility
 Louis.Text.Utf8Utility
+Louis.Threading.AsyncService
+Louis.Threading.AsyncService.AsyncService() -> void
+Louis.Threading.AsyncService.Dispose() -> void
+Louis.Threading.AsyncService.DisposeAsync() -> System.Threading.Tasks.ValueTask
+Louis.Threading.AsyncService.RunAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+Louis.Threading.AsyncService.StartAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<bool>!
+Louis.Threading.AsyncService.State.get -> Louis.Threading.AsyncServiceState
+Louis.Threading.AsyncService.StopAsync() -> System.Threading.Tasks.Task!
+Louis.Threading.AsyncService.TryStop() -> bool
+Louis.Threading.AsyncService.WaitUntilStartedAsync() -> System.Threading.Tasks.Task<bool>!
+Louis.Threading.AsyncService.WaitUntilStoppedAsync() -> System.Threading.Tasks.Task!
+Louis.Threading.AsyncServiceState
+Louis.Threading.AsyncServiceState.Created = 0 -> Louis.Threading.AsyncServiceState
+Louis.Threading.AsyncServiceState.Disposed = 5 -> Louis.Threading.AsyncServiceState
+Louis.Threading.AsyncServiceState.Running = 2 -> Louis.Threading.AsyncServiceState
+Louis.Threading.AsyncServiceState.Starting = 1 -> Louis.Threading.AsyncServiceState
+Louis.Threading.AsyncServiceState.Stopped = 4 -> Louis.Threading.AsyncServiceState
+Louis.Threading.AsyncServiceState.Stopping = 3 -> Louis.Threading.AsyncServiceState
 Louis.Threading.InterlockedFlag
 Louis.Threading.InterlockedFlag.CheckAndSet(bool value) -> bool
 Louis.Threading.InterlockedFlag.Equals(Louis.Threading.InterlockedFlag other) -> bool
@@ -167,3 +188,4 @@ static Louis.Threading.InterlockedFlag.operator ==(Louis.Threading.InterlockedFl
 static Louis.Threading.ValueTaskUtility.WhenAll(params System.Threading.Tasks.ValueTask[]! valueTasks) -> System.Threading.Tasks.ValueTask
 static Louis.Threading.ValueTaskUtility.WhenAll(System.Collections.Generic.IEnumerable<System.Threading.Tasks.ValueTask>! valueTasks) -> System.Threading.Tasks.ValueTask
 static readonly Louis.Text.Utf8Utility.Utf8NoBomEncoding -> System.Text.Encoding!
+virtual Louis.Threading.AsyncService.OnDisposeServiceAsync() -> System.Threading.Tasks.ValueTask

--- a/src/Louis/PublicAPI.Unshipped.txt
+++ b/src/Louis/PublicAPI.Unshipped.txt
@@ -40,6 +40,7 @@ Louis.Threading.AsyncService.AsyncService() -> void
 Louis.Threading.AsyncService.Dispose() -> void
 Louis.Threading.AsyncService.DisposeAsync() -> System.Threading.Tasks.ValueTask
 Louis.Threading.AsyncService.RunAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+Louis.Threading.AsyncService.Start(System.Threading.CancellationToken cancellationToken) -> void
 Louis.Threading.AsyncService.StartAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<bool>!
 Louis.Threading.AsyncService.State.get -> Louis.Threading.AsyncServiceState
 Louis.Threading.AsyncService.Stop() -> bool

--- a/src/Louis/PublicAPI.Unshipped.txt
+++ b/src/Louis/PublicAPI.Unshipped.txt
@@ -1,6 +1,4 @@
 #nullable enable
-abstract Louis.Threading.AsyncService.OnStartServiceAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask
-abstract Louis.Threading.AsyncService.OnStopServiceAsync() -> System.Threading.Tasks.ValueTask
 abstract Louis.Threading.AsyncService.RunServiceAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 const Louis.Diagnostics.ExceptionHelper.NullText = "<null>" -> string!
 const Louis.Diagnostics.ExceptionHelper.ToStringEmptyText = "<empty!>" -> string!
@@ -189,3 +187,5 @@ static Louis.Threading.ValueTaskUtility.WhenAll(params System.Threading.Tasks.Va
 static Louis.Threading.ValueTaskUtility.WhenAll(System.Collections.Generic.IEnumerable<System.Threading.Tasks.ValueTask>! valueTasks) -> System.Threading.Tasks.ValueTask
 static readonly Louis.Text.Utf8Utility.Utf8NoBomEncoding -> System.Text.Encoding!
 virtual Louis.Threading.AsyncService.OnDisposeServiceAsync() -> System.Threading.Tasks.ValueTask
+virtual Louis.Threading.AsyncService.OnStartServiceAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask
+virtual Louis.Threading.AsyncService.OnStopServiceAsync() -> System.Threading.Tasks.ValueTask

--- a/src/Louis/PublicAPI.Unshipped.txt
+++ b/src/Louis/PublicAPI.Unshipped.txt
@@ -1,5 +1,5 @@
 #nullable enable
-abstract Louis.Threading.AsyncService.RunServiceAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+abstract Louis.Threading.AsyncService.ExecuteAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 const Louis.Diagnostics.ExceptionHelper.NullText = "<null>" -> string!
 const Louis.Diagnostics.ExceptionHelper.ToStringEmptyText = "<empty!>" -> string!
 const Louis.Diagnostics.ExceptionHelper.ToStringNullText = "<null!>" -> string!
@@ -186,6 +186,6 @@ static Louis.Threading.InterlockedFlag.operator ==(Louis.Threading.InterlockedFl
 static Louis.Threading.ValueTaskUtility.WhenAll(params System.Threading.Tasks.ValueTask[]! valueTasks) -> System.Threading.Tasks.ValueTask
 static Louis.Threading.ValueTaskUtility.WhenAll(System.Collections.Generic.IEnumerable<System.Threading.Tasks.ValueTask>! valueTasks) -> System.Threading.Tasks.ValueTask
 static readonly Louis.Text.Utf8Utility.Utf8NoBomEncoding -> System.Text.Encoding!
-virtual Louis.Threading.AsyncService.OnDisposeServiceAsync() -> System.Threading.Tasks.ValueTask
-virtual Louis.Threading.AsyncService.OnStartServiceAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask
-virtual Louis.Threading.AsyncService.OnStopServiceAsync() -> System.Threading.Tasks.ValueTask
+virtual Louis.Threading.AsyncService.DisposeResourcesAsync() -> System.Threading.Tasks.ValueTask
+virtual Louis.Threading.AsyncService.SetupAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask
+virtual Louis.Threading.AsyncService.TeardownAsync() -> System.Threading.Tasks.ValueTask

--- a/src/Louis/PublicAPI.Unshipped.txt
+++ b/src/Louis/PublicAPI.Unshipped.txt
@@ -42,8 +42,8 @@ Louis.Threading.AsyncService.DisposeAsync() -> System.Threading.Tasks.ValueTask
 Louis.Threading.AsyncService.RunAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 Louis.Threading.AsyncService.StartAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<bool>!
 Louis.Threading.AsyncService.State.get -> Louis.Threading.AsyncServiceState
-Louis.Threading.AsyncService.StopAsync() -> System.Threading.Tasks.Task!
-Louis.Threading.AsyncService.TryStop() -> bool
+Louis.Threading.AsyncService.Stop() -> bool
+Louis.Threading.AsyncService.StopAsync() -> System.Threading.Tasks.Task<bool>!
 Louis.Threading.AsyncService.WaitUntilStartedAsync() -> System.Threading.Tasks.Task<bool>!
 Louis.Threading.AsyncService.WaitUntilStoppedAsync() -> System.Threading.Tasks.Task!
 Louis.Threading.AsyncServiceState

--- a/src/Louis/PublicAPI.Unshipped.txt
+++ b/src/Louis/PublicAPI.Unshipped.txt
@@ -189,11 +189,11 @@ static Louis.Threading.ValueTaskUtility.WhenAll(params System.Threading.Tasks.Va
 static Louis.Threading.ValueTaskUtility.WhenAll(System.Collections.Generic.IEnumerable<System.Threading.Tasks.ValueTask>! valueTasks) -> System.Threading.Tasks.ValueTask
 static readonly Louis.Text.Utf8Utility.Utf8NoBomEncoding -> System.Text.Encoding!
 virtual Louis.Threading.AsyncService.DisposeResourcesAsync() -> System.Threading.Tasks.ValueTask
-virtual Louis.Threading.AsyncService.OnExecuteCanceled() -> void
-virtual Louis.Threading.AsyncService.OnExecuteFailed(System.Exception! exception) -> void
-virtual Louis.Threading.AsyncService.OnSetupCanceled() -> void
-virtual Louis.Threading.AsyncService.OnSetupFailed(System.Exception! exception) -> void
-virtual Louis.Threading.AsyncService.OnStateChanged(Louis.Threading.AsyncServiceState oldState, Louis.Threading.AsyncServiceState newState) -> void
-virtual Louis.Threading.AsyncService.OnTeardownFailed(System.Exception! exception) -> void
+virtual Louis.Threading.AsyncService.LogExecuteCanceled() -> void
+virtual Louis.Threading.AsyncService.LogExecuteFailed(System.Exception! exception) -> void
+virtual Louis.Threading.AsyncService.LogSetupCanceled() -> void
+virtual Louis.Threading.AsyncService.LogSetupFailed(System.Exception! exception) -> void
+virtual Louis.Threading.AsyncService.LogStateChanged(Louis.Threading.AsyncServiceState oldState, Louis.Threading.AsyncServiceState newState) -> void
+virtual Louis.Threading.AsyncService.LogTeardownFailed(System.Exception! exception) -> void
 virtual Louis.Threading.AsyncService.SetupAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask
 virtual Louis.Threading.AsyncService.TeardownAsync() -> System.Threading.Tasks.ValueTask

--- a/src/Louis/Threading/AsyncService.cs
+++ b/src/Louis/Threading/AsyncService.cs
@@ -1,0 +1,366 @@
+﻿// Copyright (c) Tenacom and contributors. Licensed under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+using System.Threading.Tasks;
+using CommunityToolkit.Diagnostics;
+using Louis.Diagnostics;
+
+namespace Louis.Threading;
+
+/// <summary>
+/// Base class for long-running services.
+/// </summary>
+/// <remarks>
+/// <para>This class differs from the <see href="https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.hosting.backgroundservice">BackgroundService</see>
+/// class found in <c>Microsoft.Extensions.Hosting</c> because it gives you more control over your service:</para>
+/// <list type="bullet">
+/// <item>you can either start your service in background by calling <see cref="StartAsync"/>,
+/// or run it as a task by calling <see cref="RunAsync"/>;<description></description></item>
+/// <item>you can, optionally, override the <see cref="OnStartServiceAsync"/> and <see cref="OnStopServiceAsync"/> methods
+/// to separate setup and teardown from the core of your service;<description></description></item>
+/// <item>you can use the <see cref="State"/> to know, at any time, if your service has been started, has finished starting,
+/// is stopping, or has finished stopping;<description></description></item>
+/// <item><description>you can synchronize other tasks with your service by calling <see cref="WaitUntilStartedAsync"/>
+/// and <see cref="WaitUntilStoppedAsync"/>;</description></item>
+/// <item>you can stop your service and let it complete in the background by calling <see cref="TryStop"/>,
+/// or stop and wait for completion by calling <see cref="StopAsync"/>.<description></description></item>
+/// </list>
+/// </remarks>
+public abstract class AsyncService : IAsyncDisposable, IDisposable
+{
+    private readonly CancellationTokenSource _stoppedTokenSource = new();
+    private readonly TaskCompletionSource<bool> _startedCompletionSource = new();
+    private readonly TaskCompletionSource<bool> _stoppedCompletionSource = new();
+    private readonly object _stateSyncRoot = new();
+
+    private InterlockedFlag _disposed;
+    private AsyncServiceState _state = AsyncServiceState.Created;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AsyncService"/> class.
+    /// </summary>
+    protected AsyncService()
+    {
+    }
+
+    /// <summary>
+    /// Gets the state of the service.
+    /// </summary>
+    /// <seealso cref="AsyncServiceState"/>
+    public AsyncServiceState State
+    {
+        get
+        {
+            lock (_stateSyncRoot)
+            {
+                return _state;
+            }
+        }
+        private set
+        {
+            lock (_stateSyncRoot)
+            {
+                _state = value;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Asynchronously run an asynchronous service.
+    /// </summary>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to stop the service.</param>
+    /// <returns>
+    /// A <see cref="Task"/> that will complete when the service has stopped.
+    /// </returns>
+    /// <exception cref="InvalidOperationException">
+    /// The service has already been started, either by calling <see cref="RunAsync"/> or <see cref="StartAsync"/>.
+    /// </exception>
+    /// <remarks>
+    /// <para>You may call one of <see cref="RunAsync"/> and <see cref="StartAsync"/> at most once.</para>
+    /// </remarks>
+    public Task RunAsync(CancellationToken cancellationToken) => RunAsyncCore(false, cancellationToken);
+
+    /// <summary>
+    /// Asynchronously start an asynchronous service, then return while it continues to run in the background.
+    /// </summary>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to stop the service.</param>
+    /// <returns>
+    /// A <see cref="Task{T}">Task&lt;bool&gt;</see> that will complete as soon as the service has started
+    /// (in which case the result will be <see langword="true"/>), or it could not start, either because of an exception,
+    /// or the cancellation of <paramref name="cancellationToken"/> (in which case the result will be <see langword="false"/>).
+    /// </returns>
+    /// <exception cref="InvalidOperationException">
+    /// The service has already been started, either by calling <see cref="RunAsync"/> or <see cref="StartAsync"/>.
+    /// </exception>
+    /// <remarks>
+    /// <para>You may call one of <see cref="RunAsync"/> and <see cref="StartAsync"/> at most once.</para>
+    /// <para>If your program needs to know the exact reason why a service stops or fails to start,
+    /// do not use this method; call <see cref="RunAsync"/> instead.</para>
+    /// </remarks>
+    public Task<bool> StartAsync(CancellationToken cancellationToken)
+    {
+        _ = RunAsyncCore(true, cancellationToken);
+        return WaitUntilStartedAsync();
+    }
+
+    /// <summary>
+    /// Asynchronously stops an asynchronous service.
+    /// </summary>
+    /// <returns>
+    /// A <see cref="Task"/> that will complete as soon as the service has finished stopping.
+    /// If the service has already stopped, the returned task is already completed.
+    /// </returns>
+    /// <exception cref="InvalidOperationException">
+    /// The service has not been started yet.
+    /// </exception>
+    public Task StopAsync() => TryStop() ? WaitUntilStoppedAsync() : Task.CompletedTask;
+
+    /// <summary>
+    /// Tries to stop an asynchronous service.
+    /// </summary>
+    /// <returns>
+    /// <see langword="true"/> if the service has been stopped;
+    /// <see langword="false"/> if it had already stopped.
+    /// </returns>
+    /// <exception cref="InvalidOperationException">
+    /// The service has not been started yet.
+    /// </exception>
+    public bool TryStop() => TryStopCore(out var exception) || (exception is null ? false : throw exception);
+
+    /// <summary>
+    /// Asynchronously wait until an asynchronous service has started.
+    /// </summary>
+    /// <returns>
+    /// A <see cref="Task{T}">Task&lt;bool&gt;</see> that will complete as soon as the service has started
+    /// (in which case the result will be <see langword="true"/>), or it could not start
+    /// (in which case the result will be <see langword="false"/>).
+    /// </returns>
+    /// <remarks>
+    /// <para>If neither <see cref="RunAsync"/> nor <see cref="StartAsync"/> have been called,
+    /// the returned task will not complete until one of them is called.</para>
+    /// <para>If the service has already finished starting, the returned task is already completed.</para>
+    /// </remarks>
+    public Task<bool> WaitUntilStartedAsync() => _startedCompletionSource.Task;
+
+    /// <summary>
+    /// Asynchronously wait until an asynchronous service has stopped.
+    /// </summary>
+    /// <returns>
+    /// A <see cref="Task"/> that will complete as soon as the service has started and then stopped,
+    /// or until it has failed to start.</returns>
+    /// <remarks>
+    /// <para>If neither <see cref="RunAsync"/> nor <see cref="StartAsync"/> have been called,
+    /// the returned task will not complete until one of them is called.</para>
+    /// <para>If the service has already stopped, the returned task is already completed.</para>
+    /// </remarks>
+    public Task WaitUntilStoppedAsync() => _stoppedCompletionSource.Task;
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// <para>This method stops the service and waits for completion if it has been started,
+    /// then calls <see cref="OnDisposeServiceAsync"/> before releasing resources
+    /// held by this class.</para>
+    /// </remarks>
+    public async ValueTask DisposeAsync()
+    {
+        AsyncServiceState previousState;
+        lock (_stateSyncRoot)
+        {
+            if (!_disposed.TrySet())
+            {
+                return;
+            }
+
+            previousState = _state;
+            if (previousState < AsyncServiceState.Starting)
+            {
+                _state = AsyncServiceState.Disposed;
+            }
+        }
+
+        if (previousState < AsyncServiceState.Starting)
+        {
+            _ = _startedCompletionSource.TrySetResult(false);
+            _ = _stoppedCompletionSource.TrySetResult(true);
+        }
+        else
+        {
+            if (TryStopCore(out var exception) && exception is null)
+            {
+                await WaitUntilStoppedAsync().ConfigureAwait(false);
+            }
+
+            State = AsyncServiceState.Disposed;
+        }
+
+        await OnDisposeServiceAsync().ConfigureAwait(false);
+        _stoppedTokenSource.Dispose();
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// <para>This method exists for compatibility with older libraries (e.g. DI containers) lacking support for
+    /// <see cref="IAsyncDisposable"/>. It just calls <see cref="DisposeAsync"/> and waits for it synchronously.</para>
+    /// <para>If possible, you should use <see cref="DisposeAsync"/> instead of this method.</para>
+    /// </remarks>
+#pragma warning disable CA2012 // Use ValueTasks correctly - This is correct usage because we consume the ValueTask only once.
+    public void Dispose() => DisposeAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+#pragma warning restore CA2012 // Use ValueTasks correctly
+
+    /// <summary>
+    /// <para>Asynchronously releases managed resources owned by this instance.</para>
+    /// <para>Note that an instance of a class derived from <see cref="AsyncService"/>
+    /// cannot directly own unmanaged resources.</para>
+    /// </summary>
+    /// <returns>A <see cref="ValueTask"/> that represents the ongoing operation.</returns>
+    protected virtual ValueTask OnDisposeServiceAsync() => default;
+
+    /// <summary>
+    /// When overridden in a derived class, performs asynchronous operations
+    /// related to starting the service.
+    /// </summary>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to stop the operation.</param>
+    /// <returns>A <see cref="ValueTask"/> that represents the ongoing operation.</returns>
+    protected abstract ValueTask OnStartServiceAsync(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// When overridden in a derived class, performs asynchronous operations
+    /// related to stopping the service.
+    /// </summary>
+    /// <returns>A <see cref="ValueTask"/> that represents the ongoing operation.</returns>
+    /// <remarks>
+    /// <para>This method is called if and only if the <see cref="Task"/> returned by <see cref="StartAsync"/>
+    /// completes successfully, even if the service is prevented from starting afterwards
+    /// (for example if the <see cref="CancellationToken"/> passed to <see cref="StartAsync"/>
+    /// is canceled after <see cref="StartAsync"/> checks it for the last time).</para>
+    /// </remarks>
+    protected abstract ValueTask OnStopServiceAsync();
+
+    /// <summary>
+    /// When overridden in a derived class, performs the actual operations the service is meant to carry out.
+    /// </summary>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to stop the service.</param>
+    /// <returns>A <see cref="Task"/> representing the ongoing operation.</returns>
+    protected abstract Task RunServiceAsync(CancellationToken cancellationToken);
+
+    [DoesNotReturn]
+    private static void ThrowOnObjectDisposed(string message)
+        => throw new ObjectDisposedException(message);
+
+    [DoesNotReturn]
+    private static void ThrowMultipleExceptions(params Exception[] innerExceptions)
+        => throw new AggregateException(innerExceptions);
+
+    private bool TryStopCore(out Exception? exception)
+    {
+        lock (_stateSyncRoot)
+        {
+            switch (_state)
+            {
+                case < AsyncServiceState.Starting:
+                    exception = new InvalidOperationException("The service has not been started yet.");
+                    return false;
+                case > AsyncServiceState.Running:
+                    exception = null;
+                    return false;
+            }
+
+            _state = AsyncServiceState.Stopping;
+        }
+
+        _stoppedTokenSource.Cancel();
+        exception = null;
+        return true;
+    }
+
+    private async Task RunAsyncCore(bool runInBackground, CancellationToken cancellationToken)
+    {
+        lock (_stateSyncRoot)
+        {
+            switch (_state)
+            {
+                case AsyncServiceState.Created:
+                    _state = AsyncServiceState.Starting;
+                    break;
+                case AsyncServiceState.Disposed:
+                    ThrowOnObjectDisposed("Trying to run a disposed async service.");
+                    break;
+                default:
+                    ThrowHelper.ThrowInvalidOperationException("An async service cannot be started more than once.");
+                    return;
+            }
+        }
+
+        // Return immediately when called from StartAsync;
+        // continue synchronously when called from RunAsync.
+        if (runInBackground)
+        {
+            await Task.Yield();
+        }
+
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(_stoppedTokenSource.Token, cancellationToken);
+        var onStartCalled = false;
+        Exception? exception = null;
+        try
+        {
+            try
+            {
+                // Perform start actions.
+                await OnStartServiceAsync(cts.Token).ConfigureAwait(false);
+                onStartCalled = true;
+
+                // Check the cancellation token, in case cancellation has been requested
+                // but StartServiceAsync has not honored the request.
+                cts.Token.ThrowIfCancellationRequested();
+            }
+            catch
+            {
+                _startedCompletionSource.SetResult(false);
+                throw;
+            }
+
+            State = AsyncServiceState.Running;
+            _startedCompletionSource.SetResult(true);
+            await RunServiceAsync(cts.Token).ConfigureAwait(false);
+        }
+        catch (Exception e) when (!e.IsCriticalError())
+        {
+            exception = e;
+        }
+
+        if (onStartCalled)
+        {
+            State = AsyncServiceState.Stopping;
+            try
+            {
+                await OnStopServiceAsync().ConfigureAwait(false);
+            }
+            catch (Exception) when (exception is null)
+            {
+                throw;
+            }
+            catch (Exception e) when (!e.IsCriticalError())
+            {
+                ThrowMultipleExceptions(exception!, e);
+            }
+            finally
+            {
+                State = AsyncServiceState.Stopped;
+            }
+        }
+        else
+        {
+            State = AsyncServiceState.Stopping;
+        }
+
+        _stoppedCompletionSource.SetResult(true);
+        if (exception is not null)
+        {
+            ExceptionDispatchInfo.Capture(exception).Throw();
+        }
+    }
+}

--- a/src/Louis/Threading/AsyncService.cs
+++ b/src/Louis/Threading/AsyncService.cs
@@ -327,9 +327,9 @@ public abstract class AsyncService : IAsyncDisposable, IDisposable
 
     private static void AggregateAndThrowIfNeeded(Exception? exception1, Exception? exception2)
     {
-        if (exception1 is { })
+        if (exception1 is not null)
         {
-            if (exception2 is { })
+            if (exception2 is not null)
             {
                 ThrowMultipleExceptions(exception1, exception2);
             }
@@ -338,7 +338,7 @@ public abstract class AsyncService : IAsyncDisposable, IDisposable
                 ExceptionDispatchInfo.Capture(exception1).Throw();
             }
         }
-        else if (exception2 is { })
+        else if (exception2 is not null)
         {
             ExceptionDispatchInfo.Capture(exception2).Throw();
         }
@@ -436,7 +436,7 @@ public abstract class AsyncService : IAsyncDisposable, IDisposable
             State = AsyncServiceState.Stopped;
 
             // Only propagate exceptions if there is a caller to propagate to.
-            if (!runInBackground && exception is not null)
+            if (exception is not null && !runInBackground)
             {
                 ExceptionDispatchInfo.Capture(exception).Throw();
             }

--- a/src/Louis/Threading/AsyncService.cs
+++ b/src/Louis/Threading/AsyncService.cs
@@ -217,6 +217,7 @@ public abstract class AsyncService : IAsyncDisposable, IDisposable
         State = AsyncServiceState.Disposed;
         await DisposeResourcesAsync().ConfigureAwait(false);
         _stoppedTokenSource.Dispose();
+        _doneTokenSource.Dispose();
     }
 
     /// <inheritdoc />

--- a/src/Louis/Threading/AsyncService.cs
+++ b/src/Louis/Threading/AsyncService.cs
@@ -225,7 +225,7 @@ public abstract class AsyncService : IAsyncDisposable, IDisposable
     /// </summary>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to stop the operation.</param>
     /// <returns>A <see cref="ValueTask"/> that represents the ongoing operation.</returns>
-    protected abstract ValueTask OnStartServiceAsync(CancellationToken cancellationToken);
+    protected virtual ValueTask OnStartServiceAsync(CancellationToken cancellationToken) => default;
 
     /// <summary>
     /// When overridden in a derived class, performs asynchronous operations
@@ -238,7 +238,7 @@ public abstract class AsyncService : IAsyncDisposable, IDisposable
     /// (for example if the <see cref="CancellationToken"/> passed to <see cref="StartAsync"/>
     /// is canceled after <see cref="StartAsync"/> checks it for the last time).</para>
     /// </remarks>
-    protected abstract ValueTask OnStopServiceAsync();
+    protected virtual ValueTask OnStopServiceAsync() => default;
 
     /// <summary>
     /// When overridden in a derived class, performs the actual operations the service is meant to carry out.

--- a/src/Louis/Threading/AsyncService.cs
+++ b/src/Louis/Threading/AsyncService.cs
@@ -270,7 +270,7 @@ public abstract class AsyncService : IAsyncDisposable, IDisposable
     /// </summary>
     /// <param name="oldState">The old value of <see cref="State"/>.</param>
     /// <param name="newState">The new value of <see cref="State"/>.</param>
-    protected virtual void OnStateChanged(AsyncServiceState oldState, AsyncServiceState newState)
+    protected virtual void LogStateChanged(AsyncServiceState oldState, AsyncServiceState newState)
     {
     }
 
@@ -279,7 +279,7 @@ public abstract class AsyncService : IAsyncDisposable, IDisposable
     /// and the service has been requested to stop.</para>
     /// <para>This method must return as early as possible, must not throw, and should be only used for logging purposes.</para>
     /// </summary>
-    protected virtual void OnSetupCanceled()
+    protected virtual void LogSetupCanceled()
     {
     }
 
@@ -289,7 +289,7 @@ public abstract class AsyncService : IAsyncDisposable, IDisposable
     /// <para>This method must return as early as possible, must not throw, and should be only used for logging purposes.</para>
     /// </summary>
     /// <param name="exception">The exception thrown by <see cref="SetupAsync"/>.</param>
-    protected virtual void OnSetupFailed(Exception exception)
+    protected virtual void LogSetupFailed(Exception exception)
     {
     }
 
@@ -298,7 +298,7 @@ public abstract class AsyncService : IAsyncDisposable, IDisposable
     /// and the service has been requested to stop.</para>
     /// <para>This method must return as early as possible, must not throw, and should be only used for logging purposes.</para>
     /// </summary>
-    protected virtual void OnExecuteCanceled()
+    protected virtual void LogExecuteCanceled()
     {
     }
 
@@ -308,7 +308,7 @@ public abstract class AsyncService : IAsyncDisposable, IDisposable
     /// <para>This method must return as early as possible, must not throw, and should be only used for logging purposes.</para>
     /// </summary>
     /// <param name="exception">The exception thrown by <see cref="ExecuteAsync"/>.</param>
-    protected virtual void OnExecuteFailed(Exception exception)
+    protected virtual void LogExecuteFailed(Exception exception)
     {
     }
 
@@ -317,7 +317,7 @@ public abstract class AsyncService : IAsyncDisposable, IDisposable
     /// <para>This method must return as early as possible, must not throw, and should be only used for logging purposes.</para>
     /// </summary>
     /// <param name="exception">The exception thrown by <see cref="TeardownAsync"/>.</param>
-    protected virtual void OnTeardownFailed(Exception exception)
+    protected virtual void LogTeardownFailed(Exception exception)
     {
     }
 
@@ -420,11 +420,11 @@ public abstract class AsyncService : IAsyncDisposable, IDisposable
         }
         catch (OperationCanceledException) when (cts.IsCancellationRequested)
         {
-            OnSetupCanceled();
+            LogSetupCanceled();
         }
         catch (Exception e) when (!e.IsCriticalError())
         {
-            OnSetupFailed(e);
+            LogSetupFailed(e);
             exception = e;
         }
 
@@ -452,11 +452,11 @@ public abstract class AsyncService : IAsyncDisposable, IDisposable
         }
         catch (OperationCanceledException) when (cts.IsCancellationRequested)
         {
-            OnExecuteCanceled();
+            LogExecuteCanceled();
         }
         catch (Exception e) when (!e.IsCriticalError())
         {
-            OnExecuteFailed(e);
+            LogExecuteFailed(e);
             exception = e;
         }
 
@@ -469,7 +469,7 @@ public abstract class AsyncService : IAsyncDisposable, IDisposable
         }
         catch (Exception e) when (!e.IsCriticalError())
         {
-            OnTeardownFailed(e);
+            LogTeardownFailed(e);
             teardownException = e;
         }
 
@@ -487,6 +487,6 @@ public abstract class AsyncService : IAsyncDisposable, IDisposable
 
         var oldState = _state;
         _state = value;
-        OnStateChanged(oldState, _state);
+        LogStateChanged(oldState, _state);
     }
 }

--- a/src/Louis/Threading/AsyncService.cs
+++ b/src/Louis/Threading/AsyncService.cs
@@ -19,15 +19,15 @@ namespace Louis.Threading;
 /// class found in <c>Microsoft.Extensions.Hosting</c> because it gives you more control over your service:</para>
 /// <list type="bullet">
 /// <item>you can either start your service in background by calling <see cref="StartAsync"/>,
-/// or run it as a task by calling <see cref="RunAsync"/>;<description></description></item>
+/// or run it as a task by calling <see cref="RunAsync"/>;</item>
 /// <item>you can, optionally, override the <see cref="OnStartServiceAsync"/> and <see cref="OnStopServiceAsync"/> methods
-/// to separate setup and teardown from the core of your service;<description></description></item>
+/// to separate setup and teardown from the core of your service;</item>
 /// <item>you can use the <see cref="State"/> to know, at any time, if your service has been started, has finished starting,
-/// is stopping, or has finished stopping;<description></description></item>
-/// <item><description>you can synchronize other tasks with your service by calling <see cref="WaitUntilStartedAsync"/>
-/// and <see cref="WaitUntilStoppedAsync"/>;</description></item>
+/// is stopping, or has finished stopping;</item>
+/// <item>you can synchronize other tasks with your service by calling <see cref="WaitUntilStartedAsync"/>
+/// and <see cref="WaitUntilStoppedAsync"/>;</item>
 /// <item>you can stop your service and let it complete in the background by calling <see cref="TryStop"/>,
-/// or stop and wait for completion by calling <see cref="StopAsync"/>.<description></description></item>
+/// or stop and wait for completion by calling <see cref="StopAsync"/>.</item>
 /// </list>
 /// </remarks>
 public abstract class AsyncService : IAsyncDisposable, IDisposable

--- a/src/Louis/Threading/AsyncService.cs
+++ b/src/Louis/Threading/AsyncService.cs
@@ -144,7 +144,10 @@ public abstract class AsyncService : IAsyncDisposable, IDisposable
     {
         lock (_stateSyncRoot)
         {
-            return StopCore();
+            var previousState = _state;
+            var result = StopCore();
+            LogStopRequested(previousState, _state, result);
+            return result;
         }
 
         bool StopCore()
@@ -354,6 +357,18 @@ public abstract class AsyncService : IAsyncDisposable, IDisposable
     /// </summary>
     /// <param name="exception">The exception thrown by <see cref="TeardownAsync"/>.</param>
     protected virtual void LogTeardownFailed(Exception exception)
+    {
+    }
+
+    /// <summary>
+    /// <para>Called upon requesting that a service stops.</para>
+    /// <para>This method must return as early as possible, must not throw, and should be only used for logging purposes.</para>
+    /// </summary>
+    /// <param name="previousState">The value of the <see cref="State"/> property before the stop request.</param>
+    /// <param name="currentState">The value of the <see cref="State"/> property after the stop request.</param>
+    /// <param name="result"><see langword="true"/> if the service was running when requested to stop;
+    /// <see langword="false"/> otherwise.</param>
+    protected virtual void LogStopRequested(AsyncServiceState previousState, AsyncServiceState currentState, bool result)
     {
     }
 

--- a/src/Louis/Threading/AsyncService.cs
+++ b/src/Louis/Threading/AsyncService.cs
@@ -163,9 +163,9 @@ public abstract class AsyncService : IAsyncDisposable, IDisposable
                     return true;
 
                 case AsyncServiceState.Stopping:
-                case AsyncServiceState.Stopped:
                     return true;
 
+                case AsyncServiceState.Stopped:
                 case AsyncServiceState.Disposed:
                     return false;
 

--- a/src/Louis/Threading/AsyncServiceState.cs
+++ b/src/Louis/Threading/AsyncServiceState.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Tenacom and contributors. Licensed under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Louis.Threading;
+
+/// <summary>
+/// Represents the state of an <see cref="AsyncService"/>.
+/// </summary>
+public enum AsyncServiceState
+{
+    /// <summary>
+    /// The service has not started yet.
+    /// </summary>
+    Created,
+
+    /// <summary>
+    /// The service is starting but not functional yet.
+    /// </summary>
+    Starting,
+
+    /// <summary>
+    /// The service is running.
+    /// </summary>
+    Running,
+
+    /// <summary>
+    /// The service is stopping.
+    /// </summary>
+    Stopping,
+
+    /// <summary>
+    /// The service has stopped.
+    /// </summary>
+    Stopped,
+
+    /// <summary>
+    /// The service has been disposed.
+    /// </summary>
+    Disposed,
+}


### PR DESCRIPTION
## Proposed changes

- Add an `AsyncService` class to simplify the development and use of long-running background tasks.
- Add a `Louis.Hosting` package with an `AsyncHostedService` class, derived from `AsyncService`, that implements `IHostedService` and can thus be seamlessly integrated with any `IHostBuilder`-based application.

### Checklist of related issues / discussions

Fixes #56

## Types of changes

This pull request introduces the following types of changes:

- [ ] Bug fix <!-- This includes changes to tests and XML documentation as applicable. -->
- [x] New feature <!-- This includes changes to tests and XML documentation as applicable. -->
- [ ] Test addition / update (no changes to non-test code)
- [ ] Refactor (no changes in public API syntax or semantics)
- [ ] Performance improvement (no changes in public API syntax or semantics)
- [ ] Documentation (`docs` directory) update
- [x] Dependency addition / update
- [ ] Changes to the build scripts
- [ ] Changes to CI (workflows, bot / app configurations)
- [ ] Changes to repository files (`.gitattributes`, `.gitignore`)
- [ ] Other

### Breaking changes

This pull request introduces breaking changes:

- [ ] Yes
- [x] No

## Checklist

- **For all types of changes:**
  - [x] I have read the [Code of Conduct](https://github.com/Tenacom/.github/blob/main/CODE_OF_CONDUCT.md) and agree to be bound by it
  - [x] I have read the [Contributor Guide](https://github.com/Tenacom/.github/blob/main/CONTRIBUTING.md) and agree to follow it
- **For code changes only:**
  - [x] The project builds on my machine, via the provided build script, _with zero warnings_
  - [ ] I have added tests that prove my feature works / my fix is effective
  - [x] I have added / modified XML documentation according to changes in code
  - [x] I have checked that all the links I added or modified in XML documentation point to their intended destination
- **For documentation changes (`docs` directory) only:**
  - [ ] I have built and tested documentation locally
  - [ ] I have checked that all the links I added or modified point to their intended destination
