### PR TITLE
Add more accurate logging to async services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### New features
 
+- Added some more logging hooks to `AsyncService`. `AsyncHostedService` of course overrides all of them and logs appropriately.
+- `AsyncHostedService` now also logs when it is started / stopped by the host.
+
 ### Changes to existing features
 
 ### Bugs fixed in this release

--- a/src/Louis.Hosting/AsyncHostedService.cs
+++ b/src/Louis.Hosting/AsyncHostedService.cs
@@ -54,6 +54,20 @@ public abstract partial class AsyncHostedService : AsyncService, IHostedService
 
     /// <inheritdoc/>
     [LoggerMessage(
+        eventId: EventIds.AsyncHostedService.BeforeSetup,
+        level: LogLevel.Trace,
+        message: "Starting setup phase")]
+    protected sealed override partial void LogBeforeSetup();
+
+    /// <inheritdoc/>
+    [LoggerMessage(
+        eventId: EventIds.AsyncHostedService.SetupCompleted,
+        level: LogLevel.Trace,
+        message: "Setup phase completed")]
+    protected sealed override partial void LogSetupCompleted();
+
+    /// <inheritdoc/>
+    [LoggerMessage(
         eventId: EventIds.AsyncHostedService.SetupCanceled,
         level: LogLevel.Warning,
         message: "Service execution was canceled during setup phase")]
@@ -68,6 +82,20 @@ public abstract partial class AsyncHostedService : AsyncService, IHostedService
 
     /// <inheritdoc/>
     [LoggerMessage(
+        eventId: EventIds.AsyncHostedService.BeforeExecute,
+        level: LogLevel.Trace,
+        message: "Starting service execution")]
+    protected sealed override partial void LogBeforeExecute();
+
+    /// <inheritdoc/>
+    [LoggerMessage(
+        eventId: EventIds.AsyncHostedService.ExecuteCompleted,
+        level: LogLevel.Trace,
+        message: "Service execution completed")]
+    protected sealed override partial void LogExecuteCompleted();
+
+    /// <inheritdoc/>
+    [LoggerMessage(
         eventId: EventIds.AsyncHostedService.ExecuteCanceled,
         level: LogLevel.Warning,
         message: "Service execution was canceled")]
@@ -79,6 +107,20 @@ public abstract partial class AsyncHostedService : AsyncService, IHostedService
         level: LogLevel.Error,
         message: "Service execution failed")]
     protected sealed override partial void LogExecuteFailed(Exception exception);
+
+    /// <inheritdoc/>
+    [LoggerMessage(
+        eventId: EventIds.AsyncHostedService.BeforeTeardown,
+        level: LogLevel.Trace,
+        message: "Starting teardown phase")]
+    protected sealed override partial void LogBeforeTeardown();
+
+    /// <inheritdoc/>
+    [LoggerMessage(
+        eventId: EventIds.AsyncHostedService.TeardownCompleted,
+        level: LogLevel.Trace,
+        message: "Teardown phase completed")]
+    protected sealed override partial void LogTeardownCompleted();
 
     /// <inheritdoc/>
     [LoggerMessage(

--- a/src/Louis.Hosting/Internal/EventIds.cs
+++ b/src/Louis.Hosting/Internal/EventIds.cs
@@ -7,20 +7,20 @@ internal static class EventIds
 {
     public static class AsyncHostedService
     {
-        public const int StateChanged = 0;
-        public const int BeforeSetup = 1;
-        public const int SetupCompleted = 2;
-        public const int SetupCanceled = 3;
-        public const int SetupFailed = 4;
-        public const int BeforeExecute = 5;
-        public const int ExecuteCompleted = 6;
-        public const int ExecuteCanceled = 7;
-        public const int ExecuteFailed = 8;
-        public const int BeforeTeardown = 9;
-        public const int TeardownCompleted = 10;
-        public const int TeardownFailed = 11;
-        public const int StopRequested = 12;
-        public const int HostedServiceStarting = 13;
-        public const int HostedServiceStopping = 14;
+        public const int StateChanged = 1;
+        public const int BeforeSetup = 2;
+        public const int SetupCompleted = 3;
+        public const int SetupCanceled = 4;
+        public const int SetupFailed = 5;
+        public const int BeforeExecute = 6;
+        public const int ExecuteCompleted = 7;
+        public const int ExecuteCanceled = 8;
+        public const int ExecuteFailed = 9;
+        public const int BeforeTeardown = 10;
+        public const int TeardownCompleted = 11;
+        public const int TeardownFailed = 12;
+        public const int StopRequested = 13;
+        public const int HostedServiceStarting = 14;
+        public const int HostedServiceStopping = 15;
     }
 }

--- a/src/Louis.Hosting/Internal/EventIds.cs
+++ b/src/Louis.Hosting/Internal/EventIds.cs
@@ -8,11 +8,19 @@ internal static class EventIds
     public static class AsyncHostedService
     {
         public const int StateChanged = 0;
-        public const int SetupCanceled = 1;
-        public const int SetupFailed = 2;
-        public const int ExecuteCanceled = 3;
-        public const int ExecuteFailed = 4;
-        public const int TeardownFailed = 5;
-        public const int StopRequested = 6;
+        public const int BeforeSetup = 1;
+        public const int SetupCompleted = 2;
+        public const int SetupCanceled = 3;
+        public const int SetupFailed = 4;
+        public const int BeforeExecute = 5;
+        public const int ExecuteCompleted = 6;
+        public const int ExecuteCanceled = 7;
+        public const int ExecuteFailed = 8;
+        public const int BeforeTeardown = 9;
+        public const int TeardownCompleted = 10;
+        public const int TeardownFailed = 11;
+        public const int StopRequested = 12;
+        public const int HostedServiceStarting = 13;
+        public const int HostedServiceStopping = 14;
     }
 }

--- a/src/Louis.Hosting/PublicAPI.Unshipped.txt
+++ b/src/Louis.Hosting/PublicAPI.Unshipped.txt
@@ -1,10 +1,16 @@
 #nullable enable
 Louis.Hosting.AsyncHostedService
 Louis.Hosting.AsyncHostedService.AsyncHostedService(Microsoft.Extensions.Logging.ILogger! logger) -> void
+override sealed Louis.Hosting.AsyncHostedService.LogBeforeExecute() -> void
+override sealed Louis.Hosting.AsyncHostedService.LogBeforeSetup() -> void
+override sealed Louis.Hosting.AsyncHostedService.LogBeforeTeardown() -> void
 override sealed Louis.Hosting.AsyncHostedService.LogExecuteCanceled() -> void
+override sealed Louis.Hosting.AsyncHostedService.LogExecuteCompleted() -> void
 override sealed Louis.Hosting.AsyncHostedService.LogExecuteFailed(System.Exception! exception) -> void
 override sealed Louis.Hosting.AsyncHostedService.LogSetupCanceled() -> void
+override sealed Louis.Hosting.AsyncHostedService.LogSetupCompleted() -> void
 override sealed Louis.Hosting.AsyncHostedService.LogSetupFailed(System.Exception! exception) -> void
 override sealed Louis.Hosting.AsyncHostedService.LogStateChanged(Louis.Threading.AsyncServiceState oldState, Louis.Threading.AsyncServiceState newState) -> void
 override sealed Louis.Hosting.AsyncHostedService.LogStopRequested(Louis.Threading.AsyncServiceState previousState, Louis.Threading.AsyncServiceState currentState, bool result) -> void
+override sealed Louis.Hosting.AsyncHostedService.LogTeardownCompleted() -> void
 override sealed Louis.Hosting.AsyncHostedService.LogTeardownFailed(System.Exception! exception) -> void

--- a/src/Louis/PublicAPI.Unshipped.txt
+++ b/src/Louis/PublicAPI.Unshipped.txt
@@ -189,12 +189,18 @@ static Louis.Threading.ValueTaskUtility.WhenAll(params System.Threading.Tasks.Va
 static Louis.Threading.ValueTaskUtility.WhenAll(System.Collections.Generic.IEnumerable<System.Threading.Tasks.ValueTask>! valueTasks) -> System.Threading.Tasks.ValueTask
 static readonly Louis.Text.Utf8Utility.Utf8NoBomEncoding -> System.Text.Encoding!
 virtual Louis.Threading.AsyncService.DisposeResourcesAsync() -> System.Threading.Tasks.ValueTask
+virtual Louis.Threading.AsyncService.LogBeforeExecute() -> void
+virtual Louis.Threading.AsyncService.LogBeforeSetup() -> void
+virtual Louis.Threading.AsyncService.LogBeforeTeardown() -> void
 virtual Louis.Threading.AsyncService.LogExecuteCanceled() -> void
+virtual Louis.Threading.AsyncService.LogExecuteCompleted() -> void
 virtual Louis.Threading.AsyncService.LogExecuteFailed(System.Exception! exception) -> void
 virtual Louis.Threading.AsyncService.LogSetupCanceled() -> void
+virtual Louis.Threading.AsyncService.LogSetupCompleted() -> void
 virtual Louis.Threading.AsyncService.LogSetupFailed(System.Exception! exception) -> void
 virtual Louis.Threading.AsyncService.LogStateChanged(Louis.Threading.AsyncServiceState oldState, Louis.Threading.AsyncServiceState newState) -> void
 virtual Louis.Threading.AsyncService.LogStopRequested(Louis.Threading.AsyncServiceState previousState, Louis.Threading.AsyncServiceState currentState, bool result) -> void
+virtual Louis.Threading.AsyncService.LogTeardownCompleted() -> void
 virtual Louis.Threading.AsyncService.LogTeardownFailed(System.Exception! exception) -> void
 virtual Louis.Threading.AsyncService.SetupAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask
 virtual Louis.Threading.AsyncService.TeardownAsync() -> System.Threading.Tasks.ValueTask

--- a/src/Louis/Threading/AsyncService.cs
+++ b/src/Louis/Threading/AsyncService.cs
@@ -282,6 +282,22 @@ public abstract class AsyncService : IAsyncDisposable, IDisposable
     }
 
     /// <summary>
+    /// <para>Called just before calling the <see cref="SetupAsync"/> method.</para>
+    /// <para>This method must return as early as possible, must not throw, and should be only used for logging purposes.</para>
+    /// </summary>
+    protected virtual void LogBeforeSetup()
+    {
+    }
+
+    /// <summary>
+    /// <para>Called if the <see cref="SetupAsync"/> method terminates successfully.</para>
+    /// <para>This method must return as early as possible, must not throw, and should be only used for logging purposes.</para>
+    /// </summary>
+    protected virtual void LogSetupCompleted()
+    {
+    }
+
+    /// <summary>
     /// <para>Called if the <see cref="SetupAsync"/> method throws <see cref="OperationCanceledException"/>
     /// and the service has been requested to stop.</para>
     /// <para>This method must return as early as possible, must not throw, and should be only used for logging purposes.</para>
@@ -301,6 +317,22 @@ public abstract class AsyncService : IAsyncDisposable, IDisposable
     }
 
     /// <summary>
+    /// <para>Called just before calling the <see cref="ExecuteAsync"/> method.</para>
+    /// <para>This method must return as early as possible, must not throw, and should be only used for logging purposes.</para>
+    /// </summary>
+    protected virtual void LogBeforeExecute()
+    {
+    }
+
+    /// <summary>
+    /// <para>Called if the <see cref="ExecuteAsync"/> method terminates successfully.</para>
+    /// <para>This method must return as early as possible, must not throw, and should be only used for logging purposes.</para>
+    /// </summary>
+    protected virtual void LogExecuteCompleted()
+    {
+    }
+
+    /// <summary>
     /// <para>Called if the <see cref="ExecuteAsync"/> method throws <see cref="OperationCanceledException"/>
     /// and the service has been requested to stop.</para>
     /// <para>This method must return as early as possible, must not throw, and should be only used for logging purposes.</para>
@@ -316,6 +348,22 @@ public abstract class AsyncService : IAsyncDisposable, IDisposable
     /// </summary>
     /// <param name="exception">The exception thrown by <see cref="ExecuteAsync"/>.</param>
     protected virtual void LogExecuteFailed(Exception exception)
+    {
+    }
+
+    /// <summary>
+    /// <para>Called just before calling the <see cref="TeardownAsync"/> method.</para>
+    /// <para>This method must return as early as possible, must not throw, and should be only used for logging purposes.</para>
+    /// </summary>
+    protected virtual void LogBeforeTeardown()
+    {
+    }
+
+    /// <summary>
+    /// <para>Called if the <see cref="TeardownAsync"/> method terminates successfully.</para>
+    /// <para>This method must return as early as possible, must not throw, and should be only used for logging purposes.</para>
+    /// </summary>
+    protected virtual void LogTeardownCompleted()
     {
     }
 
@@ -417,7 +465,9 @@ public abstract class AsyncService : IAsyncDisposable, IDisposable
             cancellationToken.ThrowIfCancellationRequested();
 
             // Perform start actions.
+            LogBeforeSetup();
             await SetupAsync(cancellationToken).ConfigureAwait(false);
+            LogSetupCompleted();
 
             // Check the cancellation token again, in case cancellation has been requested
             // but SetupAsync has not honored the request.
@@ -445,7 +495,9 @@ public abstract class AsyncService : IAsyncDisposable, IDisposable
             cancellationToken.ThrowIfCancellationRequested();
 
             // Execute the service.
+            LogBeforeExecute();
             await ExecuteAsync(cancellationToken).ConfigureAwait(false);
+            LogExecuteCompleted();
 
             // Check the cancellation token again, in case cancellation has been requested
             // but ExecuteAsync has not honored the request.
@@ -468,7 +520,9 @@ public abstract class AsyncService : IAsyncDisposable, IDisposable
     {
         try
         {
+            LogBeforeTeardown();
             await TeardownAsync().ConfigureAwait(false);
+            LogTeardownCompleted();
             return null;
         }
         catch (Exception e) when (!e.IsCriticalError())


### PR DESCRIPTION
## Proposed changes

- Add the following logging hooks to `AsyncService`:
  - `BeforeSetup`, invoked just before calling `SetupAsync`;
  - `SetupCompleted`, invoked when `SetupAsync` returns;
  - `BeforeExecute`, invoked just before calling `ExecuteAsync`;
  - `ExecuteCompleted`, invoked when `ExecuteAsync` returns;
  - `BeforeTeardown`, invoked just before calling `TeardownAsync`;
  - `TeardownCompleted`, invoked when `TeardownAsync` returns.
- Override said hooks in `AsyncHostedService`, generating log events at the `Trace` level.
- When an `AsyncHostedService` is started or stopped by the host (i.e. at the beginning of its `IHostedService.StartAsync` and `IHostedService.StopAsync` implementations), generate appropriate log events at the `Trace` level.
- Renumber log event IDs in `Louis.Hosting` so that they start from 1 instead of 0. An event ID of 0 is not, strictly speaking, invalid, but it is commonly understood as "no event ID".

### Checklist of related issues / discussions

No issue filed due to lack of time; however, this PR solves a few problems we're having in an internal project at Tenacom.

## Types of changes

This pull request introduces the following types of changes:

<!-- Put an `x` in the boxes that apply. -->

- [ ] Bug fix <!-- This includes changes to tests and XML documentation as applicable. -->
- [x] New feature <!-- This includes changes to tests and XML documentation as applicable. -->
- [ ] Test addition / update (no changes to non-test code)
- [ ] Refactor (no changes in public API syntax or semantics)
- [ ] Performance improvement (no changes in public API syntax or semantics)
- [ ] Documentation (`docs` directory) update
- [ ] Dependency addition / update
- [ ] Changes to the build scripts
- [ ] Changes to CI (workflows, bot / app configurations)
- [ ] Changes to repository files (`.gitattributes`, `.gitignore`)
- [ ] Other

### Breaking changes

This pull request introduces breaking changes:

<!-- Put an `x` in the box that applies. -->

- [ ] Yes
- [x] No

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- **For all types of changes:**
  - [x] I have read the [Code of Conduct](https://github.com/Tenacom/.github/blob/main/CODE_OF_CONDUCT.md) and agree to be bound by it
  - [x] I have read the [Contributor Guide](https://github.com/Tenacom/.github/blob/main/CONTRIBUTING.md) and agree to follow it
- **For code changes only:**
  - [x] The project builds on my machine, via the provided build script, _with zero warnings_
  - [ ] I have added tests that prove my feature works / my fix is effective
  - [x] I have added / modified XML documentation according to changes in code
  - [x] I have checked that all the links I added or modified in XML documentation point to their intended destination
- **For documentation changes (`docs` directory) only:**
  - [ ] I have built and tested documentation locally
  - [ ] I have checked that all the links I added or modified point to their intended destination
