### PR TITLE
More fluency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### New features
 
+- Added `Louis.Fluency.FluentExtensions.Chain` method group, semantically equivalent to `Invoke` but using fluent methods or lambdas that return the same type as their first parameters. Now you can use even a local function as if it were an extension method.
+
 ### Changes to existing features
 
 ### Bugs fixed in this release

--- a/docs/articles/features/fluency.md
+++ b/docs/articles/features/fluency.md
@@ -12,6 +12,19 @@ The `Invoke` fluent extension method makes a void-returning method or lambda flu
          .Append(SomeOtherValue);
   ```
 
+## Chain
+
+The `Chain` fluent extension method lets you use a same-type-returning method or lambda as if it were an extension method.
+
+  ```csharp
+  sb = sb.Append(SomeValue)
+         .Chain(AppendSeparator)
+         .Append(SomeOtherValue);
+
+	// This local function cannot be an extension method.
+	static StringBuilder AppendSeparator(StringBuilder sb) => sb.Length > 0 ? sb.Append(',') : sb;
+  ```
+
 ## If
 
 The `If` fluent extension method executes a fluent method according to a boolean condition.
@@ -34,6 +47,21 @@ The `IfElse` fluent extension method executes one of two different fluent method
           static x => x.Clear().Append('['),
           static x => x.Append(", "))
       .Append(element.Value);
+  ```
+
+## InvokeIf
+
+The `InvokeIf` fluent extension method executes a void-returning method in a fluent fashion, according to a boolean condition.
+
+  ```csharp
+  sb = sb.Append("Hello, ")
+         .InvokeIf(IsCloseFriend, AppendMyDear)
+         .Append(Name)
+         .Append('.');
+
+	// This is a silly example, in that you may just have AppendMyDear return sb.
+	// But what if this were a 3rd-party method that you cannot modify?
+	static void AppendMyDear(StringBuilder sb) => _ = sb.Append("my dear ");
   ```
 
 ## Switch

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,6 @@
+title: L.o.U.I.S.
+description: Lots of useful, interesting stuff for your .NET applications.
+---
 ![L.o.U.I.S. logo](images/banner.png)
 
 L.o.U.I.S. (pronounced _LOO-iss_, just like the name Louis) is a collection of useful types commonly needed in the development of .NET libraries and applications.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,4 @@
+---
 title: L.o.U.I.S.
 description: Lots of useful, interesting stuff for your .NET applications.
 ---

--- a/src/Louis/Fluency/FluentAction.cs
+++ b/src/Louis/Fluency/FluentAction.cs
@@ -19,24 +19,58 @@ public delegate T FluentAction<T>(T obj);
 /// Encapsulates a method that has two parameters and returns a value of the same type as the first parameter.
 /// </summary>
 /// <typeparam name="T">The type of both the first parameter and the result of the method that this delegate encapsulates.</typeparam>
-/// <typeparam name="T1">The type of the second parameter of the method that this delegate encapsulates.</typeparam>
+/// <typeparam name="TArg">The type of the second parameter of the method that this delegate encapsulates.</typeparam>
 /// <param name="obj">The first parameter of the method that this delegate encapsulates.</param>
 /// <param name="arg">The second parameter of the method that this delegate encapsulates.</param>
 /// <returns>The return value of the method that this delegate encapsulates.
 /// This is usually (but not obligatorily), at least is <typeparamref name="T"/> is a reference type,
 /// the same reference that was passed as the first parameter to the method.</returns>
-public delegate T FluentAction<T, T1>(T obj, T1 arg);
+public delegate T FluentAction<T, TArg>(T obj, TArg arg);
 
 /// <summary>
 /// Encapsulates a method that has three parameter and returns a value of the same type as the first parameter.
 /// </summary>
 /// <typeparam name="T">The type of both the first parameter and the result of the method that this delegate encapsulates.</typeparam>
-/// <typeparam name="T1">The type of the second parameter of the method that this delegate encapsulates.</typeparam>
-/// <typeparam name="T2">The type of the third parameter of the method that this delegate encapsulates.</typeparam>
+/// <typeparam name="TArg1">The type of the second parameter of the method that this delegate encapsulates.</typeparam>
+/// <typeparam name="TArg2">The type of the third parameter of the method that this delegate encapsulates.</typeparam>
 /// <param name="obj">The first parameter of the method that this delegate encapsulates.</param>
 /// <param name="arg1">The second parameter of the method that this delegate encapsulates.</param>
 /// <param name="arg2">The third parameter of the method that this delegate encapsulates.</param>
 /// <returns>The return value of the method that this delegate encapsulates.
 /// This is usually (but not obligatorily), at least is <typeparamref name="T"/> is a reference type,
 /// the same reference that was passed as the first parameter to the method.</returns>
-public delegate T FluentAction<T, T1, T2>(T obj, T1 arg1, T2 arg2);
+public delegate T FluentAction<T, TArg1, TArg2>(T obj, TArg1 arg1, TArg2 arg2);
+
+/// <summary>
+/// Encapsulates a method that has four parameter and returns a value of the same type as the first parameter.
+/// </summary>
+/// <typeparam name="T">The type of both the first parameter and the result of the method that this delegate encapsulates.</typeparam>
+/// <typeparam name="TArg1">The type of the second parameter of the method that this delegate encapsulates.</typeparam>
+/// <typeparam name="TArg2">The type of the third parameter of the method that this delegate encapsulates.</typeparam>
+/// <typeparam name="TArg3">The type of the fourth parameter of the method that this delegate encapsulates.</typeparam>
+/// <param name="obj">The first parameter of the method that this delegate encapsulates.</param>
+/// <param name="arg1">The second parameter of the method that this delegate encapsulates.</param>
+/// <param name="arg2">The third parameter of the method that this delegate encapsulates.</param>
+/// <param name="arg3">The fourth parameter of the method that this delegate encapsulates.</param>
+/// <returns>The return value of the method that this delegate encapsulates.
+/// This is usually (but not obligatorily), at least is <typeparamref name="T"/> is a reference type,
+/// the same reference that was passed as the first parameter to the method.</returns>
+public delegate T FluentAction<T, TArg1, TArg2, TArg3>(T obj, TArg1 arg1, TArg2 arg2, TArg3 arg3);
+
+/// <summary>
+/// Encapsulates a method that has four parameter and returns a value of the same type as the first parameter.
+/// </summary>
+/// <typeparam name="T">The type of both the first parameter and the result of the method that this delegate encapsulates.</typeparam>
+/// <typeparam name="TArg1">The type of the second parameter of the method that this delegate encapsulates.</typeparam>
+/// <typeparam name="TArg2">The type of the third parameter of the method that this delegate encapsulates.</typeparam>
+/// <typeparam name="TArg3">The type of the fourth parameter of the method that this delegate encapsulates.</typeparam>
+/// <typeparam name="TArg4">The type of the fifth parameter of the method that this delegate encapsulates.</typeparam>
+/// <param name="obj">The first parameter of the method that this delegate encapsulates.</param>
+/// <param name="arg1">The second parameter of the method that this delegate encapsulates.</param>
+/// <param name="arg2">The third parameter of the method that this delegate encapsulates.</param>
+/// <param name="arg3">The fourth parameter of the method that this delegate encapsulates.</param>
+/// <param name="arg4">The fifth parameter of the method that this delegate encapsulates.</param>
+/// <returns>The return value of the method that this delegate encapsulates.
+/// This is usually (but not obligatorily), at least is <typeparamref name="T"/> is a reference type,
+/// the same reference that was passed as the first parameter to the method.</returns>
+public delegate T FluentAction<T, TArg1, TArg2, TArg3, TArg4>(T obj, TArg1 arg1, TArg2 arg2, TArg3 arg3, TArg4 arg4);

--- a/src/Louis/Fluency/FluentExtensions-Chain.cs
+++ b/src/Louis/Fluency/FluentExtensions-Chain.cs
@@ -1,0 +1,130 @@
+﻿// Copyright (c) Tenacom and contributors. Licensed under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using CommunityToolkit.Diagnostics;
+
+namespace Louis.Fluency;
+
+partial class FluentExtensions
+{
+    /// <summary>
+    /// Invokes a chainable method on an object.
+    /// </summary>
+    /// <typeparam name="T">The type of the object.</typeparam>
+    /// <param name="this">The object on which this method was called.</param>
+    /// <param name="func">The chainable method to invoke on <paramref name="this"/>.</param>
+    /// <returns>The reference to <paramref name="this"/> returned by <paramref name="func"/>.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <para><paramref name="this"/> is <see langword="null"/>.</para>
+    /// <para>- or -</para>
+    /// <para><paramref name="func"/> is <see langword="null"/>.</para>
+    /// </exception>
+    public static T Chain<T>(this T @this, FluentAction<T> func)
+    {
+        Guard.IsNotNull(@this);
+        Guard.IsNotNull(func);
+
+        return func(@this);
+    }
+
+    /// <summary>
+    /// Invokes a chainable method on an object and an additional argument.
+    /// </summary>
+    /// <typeparam name="T">The type of the object.</typeparam>
+    /// <typeparam name="TArg">The type of the additional parameter to <paramref name="func"/>.</typeparam>
+    /// <param name="this">The object on which this method was called.</param>
+    /// <param name="arg">The additional argument to pass to <paramref name="func"/>.</param>
+    /// <param name="func">The chainable method to invoke on <paramref name="this"/>.</param>
+    /// <returns>The reference to <paramref name="this"/> returned by <paramref name="func"/>.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <para><paramref name="this"/> is <see langword="null"/>.</para>
+    /// <para>- or -</para>
+    /// <para><paramref name="func"/> is <see langword="null"/>.</para>
+    /// </exception>
+    public static T Chain<T, TArg>(this T @this, TArg arg, FluentAction<T, TArg> func)
+    {
+        Guard.IsNotNull(@this);
+        Guard.IsNotNull(func);
+
+        return func(@this, arg);
+    }
+
+    /// <summary>
+    /// Invokes a chainable method on an object and additional arguments.
+    /// </summary>
+    /// <typeparam name="T">The type of the object.</typeparam>
+    /// <typeparam name="TArg1">The type of the first additional parameter to <paramref name="func"/>.</typeparam>
+    /// <typeparam name="TArg2">The type of the second additional parameter to <paramref name="func"/>.</typeparam>
+    /// <param name="this">The object on which this method was called.</param>
+    /// <param name="arg1">The First additional argument to pass to <paramref name="func"/>.</param>
+    /// <param name="arg2">The second additional argument to pass to <paramref name="func"/>.</param>
+    /// <param name="func">The chainable method to invoke on <paramref name="this"/>.</param>
+    /// <returns>The reference to <paramref name="this"/> returned by <paramref name="func"/>.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <para><paramref name="this"/> is <see langword="null"/>.</para>
+    /// <para>- or -</para>
+    /// <para><paramref name="func"/> is <see langword="null"/>.</para>
+    /// </exception>
+    public static T Chain<T, TArg1, TArg2>(this T @this, TArg1 arg1, TArg2 arg2, FluentAction<T, TArg1, TArg2> func)
+    {
+        Guard.IsNotNull(@this);
+        Guard.IsNotNull(func);
+
+        return func(@this, arg1, arg2);
+    }
+
+    /// <summary>
+    /// Invokes a chainable method on an object and additional arguments.
+    /// </summary>
+    /// <typeparam name="T">The type of the object.</typeparam>
+    /// <typeparam name="TArg1">The type of the first additional parameter to <paramref name="func"/>.</typeparam>
+    /// <typeparam name="TArg2">The type of the second additional parameter to <paramref name="func"/>.</typeparam>
+    /// <typeparam name="TArg3">The type of the third additional parameter to <paramref name="func"/>.</typeparam>
+    /// <param name="this">The object on which this method was called.</param>
+    /// <param name="arg1">The First additional argument to pass to <paramref name="func"/>.</param>
+    /// <param name="arg2">The second additional argument to pass to <paramref name="func"/>.</param>
+    /// <param name="arg3">The third additional argument to pass to <paramref name="func"/>.</param>
+    /// <param name="func">The chainable method to invoke on <paramref name="this"/>.</param>
+    /// <returns>The reference to <paramref name="this"/> returned by <paramref name="func"/>.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <para><paramref name="this"/> is <see langword="null"/>.</para>
+    /// <para>- or -</para>
+    /// <para><paramref name="func"/> is <see langword="null"/>.</para>
+    /// </exception>
+    public static T Chain<T, TArg1, TArg2, TArg3>(this T @this, TArg1 arg1, TArg2 arg2, TArg3 arg3, FluentAction<T, TArg1, TArg2, TArg3> func)
+    {
+        Guard.IsNotNull(@this);
+        Guard.IsNotNull(func);
+
+        return func(@this, arg1, arg2, arg3);
+    }
+
+    /// <summary>
+    /// Invokes a chainable method on an object and additional arguments.
+    /// </summary>
+    /// <typeparam name="T">The type of the object.</typeparam>
+    /// <typeparam name="TArg1">The type of the first additional parameter to <paramref name="func"/>.</typeparam>
+    /// <typeparam name="TArg2">The type of the second additional parameter to <paramref name="func"/>.</typeparam>
+    /// <typeparam name="TArg3">The type of the third additional parameter to <paramref name="func"/>.</typeparam>
+    /// <typeparam name="TArg4">The type of the fourth additional parameter to <paramref name="func"/>.</typeparam>
+    /// <param name="this">The object on which this method was called.</param>
+    /// <param name="arg1">The First additional argument to pass to <paramref name="func"/>.</param>
+    /// <param name="arg2">The second additional argument to pass to <paramref name="func"/>.</param>
+    /// <param name="arg3">The third additional argument to pass to <paramref name="func"/>.</param>
+    /// <param name="arg4">The fourth additional argument to pass to <paramref name="func"/>.</param>
+    /// <param name="func">The chainable method to invoke on <paramref name="this"/>.</param>
+    /// <returns>The reference to <paramref name="this"/> returned by <paramref name="func"/>.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <para><paramref name="this"/> is <see langword="null"/>.</para>
+    /// <para>- or -</para>
+    /// <para><paramref name="func"/> is <see langword="null"/>.</para>
+    /// </exception>
+    public static T Chain<T, TArg1, TArg2, TArg3, TArg4>(this T @this, TArg1 arg1, TArg2 arg2, TArg3 arg3, TArg4 arg4, FluentAction<T, TArg1, TArg2, TArg3, TArg4> func)
+    {
+        Guard.IsNotNull(@this);
+        Guard.IsNotNull(func);
+
+        return func(@this, arg1, arg2, arg3, arg4);
+    }
+}

--- a/src/Louis/Fluency/FluentExtensions-Invoke.cs
+++ b/src/Louis/Fluency/FluentExtensions-Invoke.cs
@@ -35,7 +35,7 @@ partial class FluentExtensions
     /// <typeparam name="T">The type of the object.</typeparam>
     /// <typeparam name="TArg">The type of the additional parameter to <paramref name="action"/>.</typeparam>
     /// <param name="this">The object on which this method was called.</param>
-    /// <param name="arg">The additional argument to pass tp <paramref name="action"/>.</param>
+    /// <param name="arg">The additional argument to pass to <paramref name="action"/>.</param>
     /// <param name="action">The action to perform on <paramref name="this"/> and <paramref name="arg"/>.</param>
     /// <returns>A reference to <paramref name="this"/> after <paramref name="action"/> returns.</returns>
     /// <exception cref="ArgumentNullException">
@@ -59,8 +59,8 @@ partial class FluentExtensions
     /// <typeparam name="TArg1">The type of the first additional parameter to <paramref name="action"/>.</typeparam>
     /// <typeparam name="TArg2">The type of the second additional parameter to <paramref name="action"/>.</typeparam>
     /// <param name="this">The object on which this method was called.</param>
-    /// <param name="arg1">The First additional argument to pass tp <paramref name="action"/>.</param>
-    /// <param name="arg2">The second additional argument to pass tp <paramref name="action"/>.</param>
+    /// <param name="arg1">The First additional argument to pass to <paramref name="action"/>.</param>
+    /// <param name="arg2">The second additional argument to pass to <paramref name="action"/>.</param>
     /// <param name="action">The action to perform on <paramref name="this"/> and the additional arguments.</param>
     /// <returns>A reference to <paramref name="this"/> after <paramref name="action"/> returns.</returns>
     /// <exception cref="ArgumentNullException">
@@ -85,9 +85,9 @@ partial class FluentExtensions
     /// <typeparam name="TArg2">The type of the second additional parameter to <paramref name="action"/>.</typeparam>
     /// <typeparam name="TArg3">The type of the third additional parameter to <paramref name="action"/>.</typeparam>
     /// <param name="this">The object on which this method was called.</param>
-    /// <param name="arg1">The First additional argument to pass tp <paramref name="action"/>.</param>
-    /// <param name="arg2">The second additional argument to pass tp <paramref name="action"/>.</param>
-    /// <param name="arg3">The third additional argument to pass tp <paramref name="action"/>.</param>
+    /// <param name="arg1">The First additional argument to pass to <paramref name="action"/>.</param>
+    /// <param name="arg2">The second additional argument to pass to <paramref name="action"/>.</param>
+    /// <param name="arg3">The third additional argument to pass to <paramref name="action"/>.</param>
     /// <param name="action">The action to perform on <paramref name="this"/> and the additional arguments.</param>
     /// <returns>A reference to <paramref name="this"/> after <paramref name="action"/> returns.</returns>
     /// <exception cref="ArgumentNullException">
@@ -113,10 +113,10 @@ partial class FluentExtensions
     /// <typeparam name="TArg3">The type of the third additional parameter to <paramref name="action"/>.</typeparam>
     /// <typeparam name="TArg4">The type of the fourth additional parameter to <paramref name="action"/>.</typeparam>
     /// <param name="this">The object on which this method was called.</param>
-    /// <param name="arg1">The First additional argument to pass tp <paramref name="action"/>.</param>
-    /// <param name="arg2">The second additional argument to pass tp <paramref name="action"/>.</param>
-    /// <param name="arg3">The third additional argument to pass tp <paramref name="action"/>.</param>
-    /// <param name="arg4">The fourth additional argument to pass tp <paramref name="action"/>.</param>
+    /// <param name="arg1">The First additional argument to pass to <paramref name="action"/>.</param>
+    /// <param name="arg2">The second additional argument to pass to <paramref name="action"/>.</param>
+    /// <param name="arg3">The third additional argument to pass to <paramref name="action"/>.</param>
+    /// <param name="arg4">The fourth additional argument to pass to <paramref name="action"/>.</param>
     /// <param name="action">The action to perform on <paramref name="this"/> and the additional arguments.</param>
     /// <returns>A reference to <paramref name="this"/> after <paramref name="action"/> returns.</returns>
     /// <exception cref="ArgumentNullException">

--- a/src/Louis/PublicAPI.Unshipped.txt
+++ b/src/Louis/PublicAPI.Unshipped.txt
@@ -95,6 +95,11 @@ static Louis.DisposingUtility.Dispose(object? obj) -> void
 static Louis.DisposingUtility.Dispose(params object?[]! items) -> void
 static Louis.DisposingUtility.DisposeAsync(object? obj) -> System.Threading.Tasks.ValueTask
 static Louis.DisposingUtility.DisposeAsync(params object?[]! items) -> System.Threading.Tasks.ValueTask
+static Louis.Fluency.FluentExtensions.Chain<T, TArg1, TArg2, TArg3, TArg4>(this T this, TArg1 arg1, TArg2 arg2, TArg3 arg3, TArg4 arg4, Louis.Fluency.FluentAction<T, TArg1, TArg2, TArg3, TArg4>! func) -> T
+static Louis.Fluency.FluentExtensions.Chain<T, TArg1, TArg2, TArg3>(this T this, TArg1 arg1, TArg2 arg2, TArg3 arg3, Louis.Fluency.FluentAction<T, TArg1, TArg2, TArg3>! func) -> T
+static Louis.Fluency.FluentExtensions.Chain<T, TArg1, TArg2>(this T this, TArg1 arg1, TArg2 arg2, Louis.Fluency.FluentAction<T, TArg1, TArg2>! func) -> T
+static Louis.Fluency.FluentExtensions.Chain<T, TArg>(this T this, TArg arg, Louis.Fluency.FluentAction<T, TArg>! func) -> T
+static Louis.Fluency.FluentExtensions.Chain<T>(this T this, Louis.Fluency.FluentAction<T>! func) -> T
 static Louis.Fluency.FluentExtensions.ForEach<T, TElement>(this T this, System.Collections.Generic.IEnumerable<TElement>! sequence, Louis.Fluency.FluentAction<T, TElement, int>! action) -> T
 static Louis.Fluency.FluentExtensions.ForEach<T, TElement>(this T this, System.Collections.Generic.IEnumerable<TElement>! sequence, Louis.Fluency.FluentAction<T, TElement>! action) -> T
 static Louis.Fluency.FluentExtensions.ForEach<T, TElement>(this T this, System.Collections.Generic.IEnumerable<TElement>! sequence, System.Action<T, TElement, int>! action) -> T

--- a/src/Louis/PublicAPI.Unshipped.txt
+++ b/src/Louis/PublicAPI.Unshipped.txt
@@ -21,8 +21,10 @@ Louis.Diagnostics.InternalErrorException.InternalErrorException(System.Runtime.S
 Louis.Diagnostics.SelfCheck
 Louis.Diagnostics.StringBuilderExtensions
 Louis.DisposingUtility
-Louis.Fluency.FluentAction<T, T1, T2>
-Louis.Fluency.FluentAction<T, T1>
+Louis.Fluency.FluentAction<T, TArg1, TArg2, TArg3, TArg4>
+Louis.Fluency.FluentAction<T, TArg1, TArg2, TArg3>
+Louis.Fluency.FluentAction<T, TArg1, TArg2>
+Louis.Fluency.FluentAction<T, TArg>
 Louis.Fluency.FluentAction<T>
 Louis.Fluency.FluentExtensions
 Louis.RangeCheck


### PR DESCRIPTION
## Proposed changes

- Rename type parameters of `FluentAction<>` delegates from `T1`, `t2`, etc. to more descriptive `TArg1`, `TArg2`...
- Add a `Chain` fluent extension method group that acts like `Invoke` but uses same-type-returning, instead of void, methods.
- Update the fluency doc page
- Fix the title of the docs main page, because the title DocFX infers from Markdown headers ("What does L.o.U.I.S. mean?") is incorrect, not to mention embarassing when it shows up in searches.

### Checklist of related issues / discussions

No time to open an issue or discussion, sorry.

## Types of changes

This pull request introduces the following types of changes:

<!-- Put an `x` in the boxes that apply. -->

- [ ] Bug fix <!-- This includes changes to tests and XML documentation as applicable. -->
- [x] New feature <!-- This includes changes to tests and XML documentation as applicable. -->
- [ ] Test addition / update (no changes to non-test code)
- [ ] Refactor (no changes in public API syntax or semantics)
- [ ] Performance improvement (no changes in public API syntax or semantics)
- [x] Documentation (`docs` directory) update
- [ ] Dependency addition / update
- [ ] Changes to the build scripts
- [ ] Changes to CI (workflows, bot / app configurations)
- [ ] Changes to repository files (`.gitattributes`, `.gitignore`)
- [ ] Other

### Breaking changes

This pull request introduces breaking changes:

<!-- Put an `x` in the box that applies. -->

- [x] Yes - The type parameter rename in `FluentAction<>` is probably binary-breaking
- [ ] No

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- **For all types of changes:**
  - [x] I have read the [Code of Conduct](https://github.com/Tenacom/.github/blob/main/CODE_OF_CONDUCT.md) and agree to be bound by it
  - [x] I have read the [Contributor Guide](https://github.com/Tenacom/.github/blob/main/CONTRIBUTING.md) and agree to follow it
- **For code changes only:**
  - [x] The project builds on my machine, via the provided build script, _with zero warnings_
  - [ ] I have added tests that prove my feature works / my fix is effective
  - [x] I have added / modified XML documentation according to changes in code
  - [x] I have checked that all the links I added or modified in XML documentation point to their intended destination
- **For documentation changes (`docs` directory) only:**
  - [x] I have built and tested documentation locally
  - [x] I have checked that all the links I added or modified point to their intended destination
