### PR TITLE
Refactor FluentExtensions.Switch to use equality comparers instead of requiring IEquatable<T> implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes to existing features
 
+- `Louis.Fluency.FluentExtensions.Switch` has new overloads that let you specify an [`IEqualityComparer<T>`](https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.iequalitycomparer-1) interface to compare the given value with comparands associated with actions.
+- Pre-existing overloads of `Louis.Fluency.FluentExtensions.Switch` now use [`EqualityComparer<T>.Default`](https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.equalitycomparer-1.default). As a consequance, the value and comparands no longer have to implement `IEquatable<T>`. This change also makes `FluentExtensions.Switch` usable with `enum`s.
+
 ### Bugs fixed in this release
 
 ### Known problems introduced by this release

--- a/src/Louis/Fluency/FluentExtensions-Switch.cs
+++ b/src/Louis/Fluency/FluentExtensions-Switch.cs
@@ -2,6 +2,7 @@
 // See the LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using CommunityToolkit.Diagnostics;
 
 namespace Louis.Fluency;
@@ -31,8 +32,33 @@ partial class FluentExtensions
     /// <para>If <paramref name="value"/> is not equal to any of the values in <paramref name="cases"/>, this method returns immediately.</para>
     /// </remarks>
     public static T Switch<T, TValue>(this T @this, TValue value, params (TValue Comparand, FluentAction<T>? Action)[] cases)
-        where TValue : IEquatable<TValue>
-        => Switch(@this, value, null, cases);
+        => Switch(@this, EqualityComparer<TValue>.Default, value, null, cases);
+
+    /// <summary>
+    /// Selects an action to invoke on an object by comparing a given value against a list of comparands, then returns the object.
+    /// </summary>
+    /// <typeparam name="T">The type of the object.</typeparam>
+    /// <typeparam name="TValue">The type of the value being compared.</typeparam>
+    /// <param name="this">The object on which this method was called.</param>
+    /// <param name="comparer">The interface to use for comparisons.</param>
+    /// <param name="value">The value to compare.</param>
+    /// <param name="cases">
+    /// <para>An array of pairs, where each element consists of a value to compare against <paramref name="value"/>
+    /// and an optional action to perform on <paramref name="this"/> if they are equal.</para>
+    /// <para>If the action is <see langword="null"/>, no action is performed if the value is equal to <paramref name="value"/>;
+    /// instead, the method returns immediately.</para>
+    /// </param>
+    /// <returns>A reference to <paramref name="this"/> after one of the actions in <paramref name="cases"/>, if any, returns.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <para><paramref name="this"/> is <see langword="null"/>.</para>
+    /// <para>- or -</para>
+    /// <para><paramref name="cases"/> is <see langword="null"/>.</para>
+    /// </exception>
+    /// <remarks>
+    /// <para>If <paramref name="value"/> is not equal to any of the values in <paramref name="cases"/>, this method returns immediately.</para>
+    /// </remarks>
+    public static T Switch<T, TValue>(this T @this, IEqualityComparer<TValue> comparer, TValue value, params (TValue Comparand, FluentAction<T>? Action)[] cases)
+        => Switch(@this, comparer, value, null, cases);
 
     /// <summary>
     /// Selects an action to invoke on an object by comparing a given value against a list of comparands, then returns the object.
@@ -57,8 +83,33 @@ partial class FluentExtensions
     /// <para>If <paramref name="value"/> is not equal to any of the values in <paramref name="cases"/>, this method returns immediately.</para>
     /// </remarks>
     public static T Switch<T, TValue>(this T @this, TValue value, params (TValue Comparand, Action<T>? Action)[] cases)
-        where TValue : IEquatable<TValue>
-        => Switch(@this, value, null, cases);
+        => Switch(@this, EqualityComparer<TValue>.Default, value, null, cases);
+
+    /// <summary>
+    /// Selects an action to invoke on an object by comparing a given value against a list of comparands, then returns the object.
+    /// </summary>
+    /// <typeparam name="T">The type of the object.</typeparam>
+    /// <typeparam name="TValue">The type of the value being compared.</typeparam>
+    /// <param name="this">The object on which this method was called.</param>
+    /// <param name="comparer">The interface to use for comparisons.</param>
+    /// <param name="value">The value to compare.</param>
+    /// <param name="cases">
+    /// <para>An array of pairs, where each element consists of a value to compare against <paramref name="value"/>
+    /// and an optional action to perform on <paramref name="this"/> if they are equal.</para>
+    /// <para>If the action is <see langword="null"/>, no action is performed if the value is equal to <paramref name="value"/>;
+    /// instead, the method returns immediately.</para>
+    /// </param>
+    /// <returns>A reference to <paramref name="this"/> after one of the actions in <paramref name="cases"/>, if any, returns.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <para><paramref name="this"/> is <see langword="null"/>.</para>
+    /// <para>- or -</para>
+    /// <para><paramref name="cases"/> is <see langword="null"/>.</para>
+    /// </exception>
+    /// <remarks>
+    /// <para>If <paramref name="value"/> is not equal to any of the values in <paramref name="cases"/>, this method returns immediately.</para>
+    /// </remarks>
+    public static T Switch<T, TValue>(this T @this, IEqualityComparer<TValue> comparer, TValue value, params (TValue Comparand, Action<T>? Action)[] cases)
+        => Switch(@this, comparer, value, null, cases);
 
     /// <summary>
     /// Selects an action to invoke on an object by comparing a given value against a list of comparands, then returns the object.
@@ -86,14 +137,43 @@ partial class FluentExtensions
     /// <para><paramref name="cases"/> is <see langword="null"/>.</para>
     /// </exception>
     public static T Switch<T, TValue>(this T @this, TValue value, FluentAction<T>? @default, params (TValue Comparand, FluentAction<T>? Action)[] cases)
-        where TValue : IEquatable<TValue>
+        => Switch(@this, EqualityComparer<TValue>.Default, value, @default, cases);
+
+    /// <summary>
+    /// Selects an action to invoke on an object by comparing a given value against a list of comparands, then returns the object.
+    /// </summary>
+    /// <typeparam name="T">The type of the object.</typeparam>
+    /// <typeparam name="TValue">The type of the value being compared.</typeparam>
+    /// <param name="this">The object on which this method was called.</param>
+    /// <param name="comparer">The interface to use for comparisons.</param>
+    /// <param name="value">The value to compare.</param>
+    /// <param name="default">
+    /// <para>An optional action to perform on <paramref name="this"/> if <paramref name="value"/> is not equal
+    /// to any of the values in <paramref name="cases"/>.</para>
+    /// <para>If this parameter is <see langword="null"/> and <paramref name="value"/> is not equal
+    /// to any of the values in <paramref name="cases"/>, this method returns immediately.</para>
+    /// </param>
+    /// <param name="cases">
+    /// <para>An array of pairs, where each element consists of a value to compare against <paramref name="value"/>
+    /// and an optional action to perform on <paramref name="this"/> if they are equal.</para>
+    /// <para>If the action is <see langword="null"/>, no action is performed if the value is equal to <paramref name="value"/>;
+    /// instead, the method returns immediately.</para>
+    /// </param>
+    /// <returns>A reference to <paramref name="this"/> after one of the actions in <paramref name="cases"/>, if any, returns.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <para><paramref name="this"/> is <see langword="null"/>.</para>
+    /// <para>- or -</para>
+    /// <para><paramref name="cases"/> is <see langword="null"/>.</para>
+    /// </exception>
+    public static T Switch<T, TValue>(this T @this, IEqualityComparer<TValue> comparer, TValue value, FluentAction<T>? @default, params (TValue Comparand, FluentAction<T>? Action)[] cases)
     {
         Guard.IsNotNull(@this);
+        Guard.IsNotNull(comparer);
         Guard.IsNotNull(cases);
 
         foreach (var (comparand, action) in cases)
         {
-            if (value.Equals(comparand))
+            if (comparer.Equals(value, comparand))
             {
                 return action == null ? @this : action(@this);
             }
@@ -128,14 +208,43 @@ partial class FluentExtensions
     /// <para><paramref name="cases"/> is <see langword="null"/>.</para>
     /// </exception>
     public static T Switch<T, TValue>(this T @this, TValue value, FluentAction<T>? @default, params (TValue Comparand, Action<T>? Action)[] cases)
-        where TValue : IEquatable<TValue>
+        => Switch(@this, EqualityComparer<TValue>.Default, value, @default, cases);
+
+    /// <summary>
+    /// Selects an action to invoke on an object by comparing a given value against a list of comparands, then returns the object.
+    /// </summary>
+    /// <typeparam name="T">The type of the object.</typeparam>
+    /// <typeparam name="TValue">The type of the value being compared.</typeparam>
+    /// <param name="this">The object on which this method was called.</param>
+    /// <param name="comparer">The interface to use for comparisons.</param>
+    /// <param name="value">The value to compare.</param>
+    /// <param name="default">
+    /// <para>An optional action to perform on <paramref name="this"/> if <paramref name="value"/> is not equal
+    /// to any of the values in <paramref name="cases"/>.</para>
+    /// <para>If this parameter is <see langword="null"/> and <paramref name="value"/> is not equal
+    /// to any of the values in <paramref name="cases"/>, this method returns immediately.</para>
+    /// </param>
+    /// <param name="cases">
+    /// <para>An array of pairs, where each element consists of a value to compare against <paramref name="value"/>
+    /// and an optional action to perform on <paramref name="this"/> if they are equal.</para>
+    /// <para>If the action is <see langword="null"/>, no action is performed if the value is equal to <paramref name="value"/>;
+    /// instead, the method returns immediately.</para>
+    /// </param>
+    /// <returns>A reference to <paramref name="this"/> after one of the actions in <paramref name="cases"/>, if any, returns.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <para><paramref name="this"/> is <see langword="null"/>.</para>
+    /// <para>- or -</para>
+    /// <para><paramref name="cases"/> is <see langword="null"/>.</para>
+    /// </exception>
+    public static T Switch<T, TValue>(this T @this, IEqualityComparer<TValue> comparer, TValue value, FluentAction<T>? @default, params (TValue Comparand, Action<T>? Action)[] cases)
     {
         Guard.IsNotNull(@this);
+        Guard.IsNotNull(comparer);
         Guard.IsNotNull(cases);
 
         foreach (var (comparand, action) in cases)
         {
-            if (value.Equals(comparand))
+            if (comparer.Equals(value, comparand))
             {
                 action?.Invoke(@this);
                 return @this;

--- a/src/Louis/PublicAPI.Unshipped.txt
+++ b/src/Louis/PublicAPI.Unshipped.txt
@@ -124,6 +124,10 @@ static Louis.Fluency.FluentExtensions.InvokeIf<T, TArg1, TArg2, TArg3>(this T th
 static Louis.Fluency.FluentExtensions.InvokeIf<T, TArg1, TArg2>(this T this, bool condition, TArg1 arg1, TArg2 arg2, System.Action<T, TArg1, TArg2>! action) -> T
 static Louis.Fluency.FluentExtensions.InvokeIf<T, TArg>(this T this, bool condition, TArg arg, System.Action<T, TArg>! action) -> T
 static Louis.Fluency.FluentExtensions.InvokeIf<T>(this T this, bool condition, System.Action<T>! action) -> T
+static Louis.Fluency.FluentExtensions.Switch<T, TValue>(this T this, System.Collections.Generic.IEqualityComparer<TValue>! comparer, TValue value, Louis.Fluency.FluentAction<T>? default, params (TValue Comparand, Louis.Fluency.FluentAction<T>? Action)[]! cases) -> T
+static Louis.Fluency.FluentExtensions.Switch<T, TValue>(this T this, System.Collections.Generic.IEqualityComparer<TValue>! comparer, TValue value, Louis.Fluency.FluentAction<T>? default, params (TValue Comparand, System.Action<T>? Action)[]! cases) -> T
+static Louis.Fluency.FluentExtensions.Switch<T, TValue>(this T this, System.Collections.Generic.IEqualityComparer<TValue>! comparer, TValue value, params (TValue Comparand, Louis.Fluency.FluentAction<T>? Action)[]! cases) -> T
+static Louis.Fluency.FluentExtensions.Switch<T, TValue>(this T this, System.Collections.Generic.IEqualityComparer<TValue>! comparer, TValue value, params (TValue Comparand, System.Action<T>? Action)[]! cases) -> T
 static Louis.Fluency.FluentExtensions.Switch<T, TValue>(this T this, TValue value, Louis.Fluency.FluentAction<T>? default, params (TValue Comparand, Louis.Fluency.FluentAction<T>? Action)[]! cases) -> T
 static Louis.Fluency.FluentExtensions.Switch<T, TValue>(this T this, TValue value, Louis.Fluency.FluentAction<T>? default, params (TValue Comparand, System.Action<T>? Action)[]! cases) -> T
 static Louis.Fluency.FluentExtensions.Switch<T, TValue>(this T this, TValue value, params (TValue Comparand, Louis.Fluency.FluentAction<T>? Action)[]! cases) -> T


### PR DESCRIPTION
## Proposed changes

- In `Louis.Fluency.FluentExtensions.Switch`, use [`EqualityComparer<T>.Default`](https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.equalitycomparer-1.default) instead of requiring that values being compared implement `IEquatable<T>`. This will allow enums to be used as values and comparands. Enums do not implement `IEquatable<T>` for compatibility reasons, as they predate generics.
- Add `FluentExtensions.Switch` overloads that let the user specify an [`IEqualityComparer<T>`](https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.iequalitycomparer-1) interface.

### Checklist of related issues / discussions

As the issue with `FluentExtensions.Switch` not working with enums surfeced in production while on a strict deadline, there was unfortunately no time to open a proper issue.

## Types of changes

This pull request introduces the following types of changes:

<!-- Put an `x` in the boxes that apply. -->

- [ ] Bug fix <!-- This includes changes to tests and XML documentation as applicable. -->
- [x] New feature <!-- This includes changes to tests and XML documentation as applicable. -->
- [ ] Test addition / update (no changes to non-test code)
- [x] Refactor (no changes in public API syntax or semantics)
- [ ] Performance improvement (no changes in public API syntax or semantics)
- [ ] Documentation (`docs` directory) update
- [ ] Dependency addition / update
- [ ] Changes to the build scripts
- [ ] Changes to CI (workflows, bot / app configurations)
- [ ] Changes to repository files (`.gitattributes`, `.gitignore`)
- [ ] Other

### Breaking changes

This pull request introduces breaking changes:

- [ ] Yes
- [x] No (a restriction has been lifted on a type parameter in some methods; existing code will show no change in behavior, save for a negligible performance hit)

## Checklist

- **For all types of changes:**
  - [x] I have read the [Code of Conduct](https://github.com/Tenacom/.github/blob/main/CODE_OF_CONDUCT.md) and agree to be bound by it
  - [x] I have read the [Contributor Guide](https://github.com/Tenacom/.github/blob/main/CONTRIBUTING.md) and agree to follow it
- **For code changes only:**
  - [x] The project builds on my machine, via the provided build script, _with zero warnings_
  - [ ] I have added tests that prove my feature works / my fix is effective
  - [x] I have added / modified XML documentation according to changes in code
  - [x] I have checked that all the links I added or modified in XML documentation point to their intended destination
- **For documentation changes (`docs` directory) only:**
  - [ ] I have built and tested documentation locally
  - [ ] I have checked that all the links I added or modified point to their intended destination
