### PR TITLE
Add date / time related utilities and extensions.

### DIFF
--- a/src/Louis/DateOnlyExtensions-GetEndOfWeek.cs
+++ b/src/Louis/DateOnlyExtensions-GetEndOfWeek.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) Tenacom and contributors. Licensed under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Globalization;
+
+namespace Louis;
+
+partial class DateOnlyExtensions
+{
+    /// <summary>
+    /// Given a date, returns the last day of the same week, according to the current culture.
+    /// </summary>
+    /// <param name="this">The instance of <see cref="DateOnly"/> on which this method is called.</param>
+    /// <returns>An instance of <see cref="DateOnly"/> whose value represents the last day of the week of <paramref name="this"/>,
+    /// according to the current culture.</returns>
+    /// <seealso cref="CultureInfo.CurrentCulture"/>
+    /// <seealso cref="CultureInfo.DateTimeFormat"/>
+    /// <seealso cref="DateTimeFormatInfo.FirstDayOfWeek"/>
+    public static DateOnly GetEndOfWeek(this DateOnly @this)
+        => GetEndOfWeek(@this, CultureInfo.CurrentCulture);
+
+    /// <summary>
+    /// Given a date, returns the last day of the same week, according to the specified culture.
+    /// </summary>
+    /// <param name="this">The instance of <see cref="DateOnly"/> on which this method is called.</param>
+    /// <param name="culture">An object that supplies culture-specific information.</param>
+    /// <returns>An instance of <see cref="DateOnly"/> whose value represents the last day of the week of <paramref name="this"/>,
+    /// according to <paramref name="culture"/>.</returns>
+    /// <seealso cref="CultureInfo"/>
+    /// <seealso cref="CultureInfo.DateTimeFormat"/>
+    /// <seealso cref="DateTimeFormatInfo.FirstDayOfWeek"/>
+    public static DateOnly GetEndOfWeek(this DateOnly @this, CultureInfo culture)
+        => GetEndOfWeek(@this, culture.DateTimeFormat);
+
+    /// <summary>
+    /// Given a date, returns the last day of the same week, according to the specified formatting information.
+    /// </summary>
+    /// <param name="this">The instance of <see cref="DateOnly"/> on which this method is called.</param>
+    /// <param name="dateTimeFormat">An object that supplies culture-specific date formatting information.</param>
+    /// <returns>An instance of <see cref="DateOnly"/> whose value represents the last day of the week of <paramref name="this"/>,
+    /// according to <paramref name="dateTimeFormat"/>.</returns>
+    /// <seealso cref="DateTimeFormatInfo.FirstDayOfWeek"/>
+    public static DateOnly GetEndOfWeek(this DateOnly @this, DateTimeFormatInfo dateTimeFormat)
+        => GetEndOfWeek(@this, dateTimeFormat.FirstDayOfWeek);
+
+    /// <summary>
+    /// Returns the earliest date, greater or equal to a given date, whose day of the week is the one preceding a specified day of the week.
+    /// </summary>
+    /// <param name="this">The instance of <see cref="DateOnly"/> on which this method is called.</param>
+    /// <param name="firstDayOfWeek">A <see cref="DayOfWeek"/> value representing the day that starts the week.</param>
+    /// <returns>An instance of <see cref="DateOnly"/> whose value represents the last day of the week of <paramref name="this"/>,
+    /// if weeks are considered starting with <paramref name="firstDayOfWeek"/>.</returns>
+    /// <seealso cref="DayOfWeek"/>
+    public static DateOnly GetEndOfWeek(this DateOnly @this, DayOfWeek firstDayOfWeek)
+        => @this.AddDays(6 - DateUtility.GetDaysFromStartOfWeek(@this.DayOfWeek, firstDayOfWeek));
+}

--- a/src/Louis/DateOnlyExtensions-GetStartOfWeek.cs
+++ b/src/Louis/DateOnlyExtensions-GetStartOfWeek.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) Tenacom and contributors. Licensed under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Globalization;
+using CommunityToolkit.Diagnostics;
+
+namespace Louis;
+
+partial class DateOnlyExtensions
+{
+    /// <summary>
+    /// Given a date, returns the first day of the same week, according to the current culture.
+    /// </summary>
+    /// <param name="this">The instance of <see cref="DateOnly"/> on which this method is called.</param>
+    /// <returns>An instance of <see cref="DateOnly"/> whose value represents the first day of the week of <paramref name="this"/>,
+    /// according to the current culture.</returns>
+    /// <seealso cref="CultureInfo.CurrentCulture"/>
+    /// <seealso cref="CultureInfo.DateTimeFormat"/>
+    /// <seealso cref="DateTimeFormatInfo.FirstDayOfWeek"/>
+    public static DateOnly GetStartOfWeek(this DateOnly @this)
+        => GetStartOfWeek(@this, CultureInfo.CurrentCulture.DateTimeFormat.FirstDayOfWeek);
+
+    /// <summary>
+    /// Given a date, returns the first day of the same week, according to the specified culture.
+    /// </summary>
+    /// <param name="this">The instance of <see cref="DateOnly"/> on which this method is called.</param>
+    /// <param name="culture">An object that supplies culture-specific information.</param>
+    /// <returns>An instance of <see cref="DateOnly"/> whose value represents the first day of the week of <paramref name="this"/>,
+    /// according to <paramref name="culture"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="culture"/> is <see langword="null"/>.</exception>
+    /// <seealso cref="CultureInfo"/>
+    /// <seealso cref="CultureInfo.DateTimeFormat"/>
+    /// <seealso cref="DateTimeFormatInfo.FirstDayOfWeek"/>
+    public static DateOnly GetStartOfWeek(this DateOnly @this, CultureInfo culture)
+    {
+        Guard.IsNotNull(culture);
+        return GetStartOfWeek(@this, culture.DateTimeFormat.FirstDayOfWeek);
+    }
+
+    /// <summary>
+    /// Given a date, returns the first day of the same week, according to the specified formatting information.
+    /// </summary>
+    /// <param name="this">The instance of <see cref="DateOnly"/> on which this method is called.</param>
+    /// <param name="dateTimeFormat">An object that supplies culture-specific date formatting information.</param>
+    /// <returns>An instance of <see cref="DateOnly"/> whose value represents the first day of the week of <paramref name="this"/>,
+    /// according to <paramref name="dateTimeFormat"/>.</returns>
+    /// <seealso cref="DateTimeFormatInfo.FirstDayOfWeek"/>
+    public static DateOnly GetStartOfWeek(this DateOnly @this, DateTimeFormatInfo dateTimeFormat)
+        => GetStartOfWeek(@this, dateTimeFormat.FirstDayOfWeek);
+
+    /// <summary>
+    /// Returns the most recent date, earlier or equal to a given date, whose day of the week is equal to a specified day of the week.
+    /// </summary>
+    /// <param name="this">The instance of <see cref="DateOnly"/> on which this method is called.</param>
+    /// <param name="firstDayOfWeek">A <see cref="DayOfWeek"/> value representing the day that starts the week.</param>
+    /// <returns>An instance of <see cref="DateOnly"/> whose value represents the first day of the week of <paramref name="this"/>,
+    /// if weeks are considered starting with <paramref name="firstDayOfWeek"/>.</returns>
+    /// <seealso cref="DayOfWeek"/>
+    public static DateOnly GetStartOfWeek(this DateOnly @this, DayOfWeek firstDayOfWeek)
+        => @this.AddDays(-DateUtility.GetDaysFromStartOfWeek(@this.DayOfWeek, firstDayOfWeek));
+}

--- a/src/Louis/DateOnlyExtensions.cs
+++ b/src/Louis/DateOnlyExtensions.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Tenacom and contributors. Licensed under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Louis;
+
+/// <summary>
+/// Provides extension methods for instances of <see cref="DateOnly"/>.
+/// </summary>
+public static partial class DateOnlyExtensions
+{
+    /// <summary>
+    /// Given a date, returns the first day of the same month.
+    /// </summary>
+    /// <param name="this">The instance of <see cref="DateTime"/> on which this method is called.</param>
+    /// <returns>An instance of <see cref="DateTime"/> whose value represents the first day of the month of <paramref name="this"/>.</returns>
+    public static DateOnly GetStartOfMonth(this DateOnly @this)
+        => @this.AddDays(1 - @this.Day);
+
+    /// <summary>
+    /// Given a date, returns the last day of the same month.
+    /// </summary>
+    /// <param name="this">The instance of <see cref="DateTime"/> on which this method is called.</param>
+    /// <returns>An instance of <see cref="DateTime"/> whose value represents the last day of the month of <paramref name="this"/>.</returns>
+    public static DateOnly GetEndOfMonth(this DateOnly @this)
+        => @this.AddDays(DateTime.DaysInMonth(@this.Year, @this.Month) - @this.Day);
+}

--- a/src/Louis/DateOnlyUtility.cs
+++ b/src/Louis/DateOnlyUtility.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Tenacom and contributors. Licensed under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Louis;
+
+/// <summary>
+/// Provides utility methods to work with <see cref="DateOnly"/>.
+/// </summary>
+public static class DateOnlyUtility
+{
+    /// <summary>
+    /// Gets a <see cref="DateOnly"/> instance whose value represents the current date.
+    /// </summary>
+    public static DateOnly Today => DateOnly.FromDateTime(DateTime.Today);
+}

--- a/src/Louis/DateTimeExtensions-GetEndOfWeek.cs
+++ b/src/Louis/DateTimeExtensions-GetEndOfWeek.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) Tenacom and contributors. Licensed under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Globalization;
+using CommunityToolkit.Diagnostics;
+
+namespace Louis;
+
+partial class DateTimeExtensions
+{
+    /// <summary>
+    /// Given a date and time, returns the last tick of the last day of the same week, according to the current culture.
+    /// </summary>
+    /// <param name="this">The instance of <see cref="DateTime"/> on which this method is called.</param>
+    /// <returns>An instance of <see cref="DateTime"/> whose value represents the last day of the week of <paramref name="this"/>,
+    /// according to the current culture.</returns>
+    /// <seealso cref="CultureInfo.CurrentCulture"/>
+    /// <seealso cref="CultureInfo.DateTimeFormat"/>
+    /// <seealso cref="DateTimeFormatInfo.FirstDayOfWeek"/>
+    public static DateTime GetEndOfWeek(this DateTime @this)
+        => GetEndOfWeek(@this, CultureInfo.CurrentCulture);
+
+    /// <summary>
+    /// Given a date and time, returns the last tick of the last day of the same week, according to the specified culture.
+    /// </summary>
+    /// <param name="this">The instance of <see cref="DateTime"/> on which this method is called.</param>
+    /// <param name="culture">An object that supplies culture-specific information.</param>
+    /// <returns>An instance of <see cref="DateTime"/> whose value represents the last day of the week of <paramref name="this"/>,
+    /// according to <paramref name="culture"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="culture"/> is <see langword="null"/>.</exception>
+    /// <seealso cref="CultureInfo"/>
+    /// <seealso cref="CultureInfo.DateTimeFormat"/>
+    /// <seealso cref="DateTimeFormatInfo.FirstDayOfWeek"/>
+    public static DateTime GetEndOfWeek(this DateTime @this, CultureInfo culture)
+    {
+        Guard.IsNotNull(culture);
+        return GetEndOfWeek(@this, culture.DateTimeFormat);
+    }
+
+    /// <summary>
+    /// Given a date and time, returns the last tick of the last day of the same week, according to the specified formatting information.
+    /// </summary>
+    /// <param name="this">The instance of <see cref="DateTime"/> on which this method is called.</param>
+    /// <param name="dateTimeFormat">An object that supplies culture-specific date formatting information.</param>
+    /// <returns>An instance of <see cref="DateTime"/> whose value represents the last day of the week of <paramref name="this"/>,
+    /// according to <paramref name="dateTimeFormat"/>.</returns>
+    /// <seealso cref="DateTimeFormatInfo.FirstDayOfWeek"/>
+    public static DateTime GetEndOfWeek(this DateTime @this, DateTimeFormatInfo dateTimeFormat)
+        => GetEndOfWeek(@this, dateTimeFormat.FirstDayOfWeek);
+
+    /// <summary>
+    /// Returns the last tick of the earliest date, greater or equal to a given date, whose day of the week is the one preceding a specified day of the week.
+    /// </summary>
+    /// <param name="this">The instance of <see cref="DateTime"/> on which this method is called.</param>
+    /// <param name="firstDayOfWeek">A <see cref="DayOfWeek"/> value representing the day that starts the week.</param>
+    /// <returns>An instance of <see cref="DateTime"/> whose value represents the last day of the week of <paramref name="this"/>,
+    /// if weeks are considered starting with <paramref name="firstDayOfWeek"/>.</returns>
+    /// <seealso cref="DayOfWeek"/>
+    public static DateTime GetEndOfWeek(this DateTime @this, DayOfWeek firstDayOfWeek)
+        => @this.AddDays(6 - DateUtility.GetDaysFromStartOfWeek(@this.DayOfWeek, firstDayOfWeek));
+}

--- a/src/Louis/DateTimeExtensions-GetLastDayOfWeek.cs
+++ b/src/Louis/DateTimeExtensions-GetLastDayOfWeek.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) Tenacom and contributors. Licensed under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Globalization;
+using CommunityToolkit.Diagnostics;
+
+namespace Louis;
+
+partial class DateTimeExtensions
+{
+    /// <summary>
+    /// Given a date and time, returns midnight on the last day of the same week, according to the current culture.
+    /// </summary>
+    /// <param name="this">The instance of <see cref="DateTime"/> on which this method is called.</param>
+    /// <returns>An instance of <see cref="DateTime"/> whose value represents the last day of the week of <paramref name="this"/>,
+    /// according to the current culture.</returns>
+    /// <seealso cref="CultureInfo.CurrentCulture"/>
+    /// <seealso cref="CultureInfo.DateTimeFormat"/>
+    /// <seealso cref="DateTimeFormatInfo.FirstDayOfWeek"/>
+    public static DateTime GetLastDayOfWeek(this DateTime @this)
+        => GetLastDayOfWeek(@this, CultureInfo.CurrentCulture);
+
+    /// <summary>
+    /// Given a date and time, returns midnight on the last day of the same week, according to the specified culture.
+    /// </summary>
+    /// <param name="this">The instance of <see cref="DateTime"/> on which this method is called.</param>
+    /// <param name="culture">An object that supplies culture-specific information.</param>
+    /// <returns>An instance of <see cref="DateTime"/> whose value represents the last day of the week of <paramref name="this"/>,
+    /// according to <paramref name="culture"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="culture"/> is <see langword="null"/>.</exception>
+    /// <seealso cref="CultureInfo"/>
+    /// <seealso cref="CultureInfo.DateTimeFormat"/>
+    /// <seealso cref="DateTimeFormatInfo.FirstDayOfWeek"/>
+    public static DateTime GetLastDayOfWeek(this DateTime @this, CultureInfo culture)
+    {
+        Guard.IsNotNull(culture);
+        return GetLastDayOfWeek(@this, culture.DateTimeFormat);
+    }
+
+    /// <summary>
+    /// Given a date and time, returns midnight on the last day of the same week, according to the specified formatting information.
+    /// </summary>
+    /// <param name="this">The instance of <see cref="DateTime"/> on which this method is called.</param>
+    /// <param name="dateTimeFormat">An object that supplies culture-specific date formatting information.</param>
+    /// <returns>An instance of <see cref="DateTime"/> whose value represents the last day of the week of <paramref name="this"/>,
+    /// according to <paramref name="dateTimeFormat"/>.</returns>
+    /// <seealso cref="DateTimeFormatInfo.FirstDayOfWeek"/>
+    public static DateTime GetLastDayOfWeek(this DateTime @this, DateTimeFormatInfo dateTimeFormat)
+        => GetLastDayOfWeek(@this, dateTimeFormat.FirstDayOfWeek);
+
+    /// <summary>
+    /// Returns midnight on the earliest date, greater or equal to a given date and time, whose day of the week is the one preceding a specified day of the week.
+    /// </summary>
+    /// <param name="this">The instance of <see cref="DateTime"/> on which this method is called.</param>
+    /// <param name="firstDayOfWeek">A <see cref="DayOfWeek"/> value representing the day that starts the week.</param>
+    /// <returns>An instance of <see cref="DateTime"/> whose value represents the last day of the week of <paramref name="this"/>,
+    /// if weeks are considered starting with <paramref name="firstDayOfWeek"/>.</returns>
+    /// <seealso cref="DayOfWeek"/>
+    public static DateTime GetLastDayOfWeek(this DateTime @this, DayOfWeek firstDayOfWeek)
+        => @this.AddDays(6 - DateUtility.GetDaysFromStartOfWeek(@this.DayOfWeek, firstDayOfWeek));
+}

--- a/src/Louis/DateTimeExtensions-GetStartOfWeek.cs
+++ b/src/Louis/DateTimeExtensions-GetStartOfWeek.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) Tenacom and contributors. Licensed under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Globalization;
+using CommunityToolkit.Diagnostics;
+
+namespace Louis;
+
+partial class DateTimeExtensions
+{
+    /// <summary>
+    /// Given a date and time, returns midnight on the first day of the same week, according to the current culture.
+    /// </summary>
+    /// <param name="this">The instance of <see cref="DateTime"/> on which this method is called.</param>
+    /// <returns>An instance of <see cref="DateTime"/> whose value represents the first day of the week of <paramref name="this"/>,
+    /// according to the current culture.</returns>
+    /// <seealso cref="CultureInfo.CurrentCulture"/>
+    /// <seealso cref="CultureInfo.DateTimeFormat"/>
+    /// <seealso cref="DateTimeFormatInfo.FirstDayOfWeek"/>
+    public static DateTime GetStartOfWeek(this DateTime @this)
+        => GetStartOfWeek(@this, CultureInfo.CurrentCulture.DateTimeFormat.FirstDayOfWeek);
+
+    /// <summary>
+    /// Given a date and time, returns midnight on the first day of the same week, according to the specified culture.
+    /// </summary>
+    /// <param name="this">The instance of <see cref="DateTime"/> on which this method is called.</param>
+    /// <param name="culture">An object that supplies culture-specific information.</param>
+    /// <returns>An instance of <see cref="DateTime"/> whose value represents the first day of the week of <paramref name="this"/>,
+    /// according to <paramref name="culture"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="culture"/> is <see langword="null"/>.</exception>
+    /// <seealso cref="CultureInfo"/>
+    /// <seealso cref="CultureInfo.DateTimeFormat"/>
+    /// <seealso cref="DateTimeFormatInfo.FirstDayOfWeek"/>
+    public static DateTime GetStartOfWeek(this DateTime @this, CultureInfo culture)
+    {
+        Guard.IsNotNull(culture);
+        return GetStartOfWeek(@this, culture.DateTimeFormat.FirstDayOfWeek);
+    }
+
+    /// <summary>
+    /// Given a date and time, returns midnight on the first day of the same week, according to the specified formatting information.
+    /// </summary>
+    /// <param name="this">The instance of <see cref="DateTime"/> on which this method is called.</param>
+    /// <param name="dateTimeFormat">An object that supplies culture-specific date formatting information.</param>
+    /// <returns>An instance of <see cref="DateTime"/> whose value represents the first day of the week of <paramref name="this"/>,
+    /// according to <paramref name="dateTimeFormat"/>.</returns>
+    /// <seealso cref="DateTimeFormatInfo.FirstDayOfWeek"/>
+    public static DateTime GetStartOfWeek(this DateTime @this, DateTimeFormatInfo dateTimeFormat)
+        => GetStartOfWeek(@this, dateTimeFormat.FirstDayOfWeek);
+
+    /// <summary>
+    /// Returns midnight on the most recent date, earlier or equal to a given date, whose day of the week is equal to a specified day of the week.
+    /// </summary>
+    /// <param name="this">The instance of <see cref="DateTime"/> on which this method is called.</param>
+    /// <param name="firstDayOfWeek">A <see cref="DayOfWeek"/> value representing the day that starts the week.</param>
+    /// <returns>An instance of <see cref="DateTime"/> whose value represents the first day of the week of <paramref name="this"/>,
+    /// if weeks are considered starting with <paramref name="firstDayOfWeek"/>.</returns>
+    /// <seealso cref="DayOfWeek"/>
+    public static DateTime GetStartOfWeek(this DateTime @this, DayOfWeek firstDayOfWeek)
+        => @this.AddDays(-DateUtility.GetDaysFromStartOfWeek(@this.DayOfWeek, firstDayOfWeek));
+}

--- a/src/Louis/DateTimeExtensions.cs
+++ b/src/Louis/DateTimeExtensions.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) Tenacom and contributors. Licensed under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Louis;
+
+/// <summary>
+/// Provides extension methods for instances of <see cref="DateTime"/>.
+/// </summary>
+public static partial class DateTimeExtensions
+{
+    /// <summary>
+    /// Given a date and time, returns the last tick of the day.
+    /// </summary>
+    /// <param name="this">The instance of <see cref="DateTime"/> on which this method is called.</param>
+    /// <returns>An instance of <see cref="DateTime"/> whose value represents the last tick on the same day as <paramref name="this"/>.</returns>
+    public static DateTime GetEndOfDay(this DateTime @this)
+        => @this.Date.AddTicks(TimeConstants.TicksPerDay - 1);
+
+    /// <summary>
+    /// Given a date and time, returns midnight on the first day of the same month.
+    /// </summary>
+    /// <param name="this">The instance of <see cref="DateTime"/> on which this method is called.</param>
+    /// <returns>An instance of <see cref="DateTime"/> whose value represents midnight on the first day of the month of <paramref name="this"/>.</returns>
+    public static DateTime GetStartOfMonth(this DateTime @this)
+        => @this.Date.AddDays(1 - @this.Day);
+
+    /// <summary>
+    /// Given a date and time, returns the last tick of the last day of the same month.
+    /// </summary>
+    /// <param name="this">The instance of <see cref="DateTime"/> on which this method is called.</param>
+    /// <returns>An instance of <see cref="DateTime"/> whose value represents the last tick of the last day of the month of <paramref name="this"/>.</returns>
+    public static DateTime GetEndOfMonth(this DateTime @this)
+        => @this.GetLastDayOfMonth().GetEndOfDay();
+
+    /// <summary>
+    /// Given a date and time, returns midnight on the last day of the same month.
+    /// </summary>
+    /// <param name="this">The instance of <see cref="DateTime"/> on which this method is called.</param>
+    /// <returns>An instance of <see cref="DateTime"/> whose value represents midnight on the last day of the month of <paramref name="this"/>.</returns>
+    public static DateTime GetLastDayOfMonth(this DateTime @this)
+        => @this.Date.AddDays(DateTime.DaysInMonth(@this.Year, @this.Month) - @this.Day);
+}

--- a/src/Louis/DateUtility-GetDaysFromStartOfWeek.cs
+++ b/src/Louis/DateUtility-GetDaysFromStartOfWeek.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) Tenacom and contributors. Licensed under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Globalization;
+using CommunityToolkit.Diagnostics;
+
+namespace Louis;
+
+partial class DateUtility
+{
+    /// <summary>
+    /// Returns the amount of full days separating a given day of the week from the first day of the same week, according to the current culture.
+    /// </summary>
+    /// <param name="today">A <see cref="DayOfWeek"/> value.</param>
+    /// <returns>An integer number between 0 and 6 representing the days between the start of the week and <paramref name="today"/>,
+    /// according to the current culture.</returns>
+    /// <seealso cref="CultureInfo.CurrentCulture"/>
+    /// <seealso cref="CultureInfo.DateTimeFormat"/>
+    /// <seealso cref="DateTimeFormatInfo.FirstDayOfWeek"/>
+    public static int GetDaysFromStartOfWeek(DayOfWeek today)
+        => GetDaysFromStartOfWeek(today, CultureInfo.CurrentCulture.DateTimeFormat.FirstDayOfWeek);
+
+    /// <summary>
+    /// Returns the amount of full days separating a given day of the week from the first day of the same week, according to the specified culture.
+    /// </summary>
+    /// <param name="today">A <see cref="DayOfWeek"/> value.</param>
+    /// <param name="culture">An object that supplies culture-specific information.</param>
+    /// <returns>An integer number between 0 and 6 representing the days between the start of the week and <paramref name="today"/>,
+    /// according to <paramref name="culture"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="culture"/> is <see langword="null"/>.</exception>
+    /// <seealso cref="CultureInfo"/>
+    /// <seealso cref="CultureInfo.DateTimeFormat"/>
+    /// <seealso cref="DateTimeFormatInfo.FirstDayOfWeek"/>
+    public static int GetDaysFromStartOfWeek(DayOfWeek today, CultureInfo culture)
+    {
+        Guard.IsNotNull(culture);
+        return GetDaysFromStartOfWeek(today, culture.DateTimeFormat.FirstDayOfWeek);
+    }
+
+    /// <summary>
+    /// Returns the amount of full days separating a given day of the week from the first day of the same week, according to the specified formatting information.
+    /// </summary>
+    /// <param name="today">A <see cref="DayOfWeek"/> value.</param>
+    /// <param name="dateTimeFormat">An object that supplies culture-specific date formatting information.</param>
+    /// <returns>An integer number between 0 and 6 representing the days between the start of the week and <paramref name="today"/>,
+    /// according to <paramref name="dateTimeFormat"/>.</returns>
+    /// <seealso cref="DateTimeFormatInfo.FirstDayOfWeek"/>
+    public static int GetDaysFromStartOfWeek(DayOfWeek today, DateTimeFormatInfo dateTimeFormat)
+        => GetDaysFromStartOfWeek(today, dateTimeFormat.FirstDayOfWeek);
+
+    /// <summary>
+    /// Returns the amount of full days separating a given day of the week from the first day of the same week, if a given day is considered the first of the week.
+    /// </summary>
+    /// <param name="today">A <see cref="DayOfWeek"/> value.</param>
+    /// <param name="firstDayOfWeek">A <see cref="DayOfWeek"/> value representing the day that starts the week.</param>
+    /// <returns>An integer number between 0 and 6 representing the days between the start of the week and <paramref name="today"/>,
+    /// if weeks are considered starting with <paramref name="firstDayOfWeek"/>.</returns>
+    /// <seealso cref="DayOfWeek"/>
+    public static int GetDaysFromStartOfWeek(DayOfWeek today, DayOfWeek firstDayOfWeek)
+        => (7 + (int)today - (int)firstDayOfWeek) & 7;
+}

--- a/src/Louis/DateUtility.cs
+++ b/src/Louis/DateUtility.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Tenacom and contributors. Licensed under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Louis;
+
+/// <summary>
+/// Provides utility methods to work with dates.
+/// </summary>
+public static partial class DateUtility
+{
+}

--- a/src/Louis/PublicAPI.Unshipped.txt
+++ b/src/Louis/PublicAPI.Unshipped.txt
@@ -3,8 +3,33 @@ abstract Louis.Threading.AsyncService.ExecuteAsync(System.Threading.Cancellation
 const Louis.Diagnostics.ExceptionHelper.NullText = "<null>" -> string!
 const Louis.Diagnostics.ExceptionHelper.ToStringEmptyText = "<empty!>" -> string!
 const Louis.Diagnostics.ExceptionHelper.ToStringNullText = "<null!>" -> string!
+const Louis.TimeConstants.DaysPerWeek = 7 -> int
+const Louis.TimeConstants.HoursPerDay = 24 -> int
+const Louis.TimeConstants.HoursPerWeek = 168 -> int
+const Louis.TimeConstants.MillisecondsPerDay = 86400000 -> int
+const Louis.TimeConstants.MillisecondsPerHour = 3600000 -> int
+const Louis.TimeConstants.MillisecondsPerMinute = 60000 -> int
+const Louis.TimeConstants.MillisecondsPerSecond = 1000 -> int
+const Louis.TimeConstants.MillisecondsPerWeek = 604800000 -> int
+const Louis.TimeConstants.MinutesPerDay = 1440 -> int
+const Louis.TimeConstants.MinutesPerHour = 60 -> int
+const Louis.TimeConstants.MinutesPerWeek = 10080 -> int
+const Louis.TimeConstants.SecondsPerDay = 86400 -> int
+const Louis.TimeConstants.SecondsPerHour = 3600 -> int
+const Louis.TimeConstants.SecondsPerMinute = 60 -> int
+const Louis.TimeConstants.SecondsPerWeek = 604800 -> int
+const Louis.TimeConstants.TicksPerDay = 864000000000 -> long
+const Louis.TimeConstants.TicksPerHour = 36000000000 -> long
+const Louis.TimeConstants.TicksPerMillisecond = 10000 -> long
+const Louis.TimeConstants.TicksPerMinute = 600000000 -> long
+const Louis.TimeConstants.TicksPerSecond = 10000000 -> long
+const Louis.TimeConstants.TicksPerWeek = 6048000000000 -> long
 Louis.AsyncDisposableExtensions
 Louis.Collections.EnumerableExtensions
+Louis.DateOnlyExtensions
+Louis.DateOnlyUtility
+Louis.DateTimeExtensions
+Louis.DateUtility
 Louis.Diagnostics.CriticalInternalErrorException
 Louis.Diagnostics.CriticalInternalErrorException.CriticalInternalErrorException() -> void
 Louis.Diagnostics.CriticalInternalErrorException.CriticalInternalErrorException(string! message) -> void
@@ -68,6 +93,7 @@ Louis.Threading.InterlockedFlag.TrySet(bool value) -> bool
 Louis.Threading.InterlockedFlag.Value.get -> bool
 Louis.Threading.InterlockedFlag.Value.set -> void
 Louis.Threading.ValueTaskUtility
+Louis.TimeConstants
 override Louis.Threading.InterlockedFlag.Equals(object? obj) -> bool
 override Louis.Threading.InterlockedFlag.GetHashCode() -> int
 override Louis.Threading.InterlockedFlag.ToString() -> string!
@@ -79,6 +105,37 @@ static Louis.Collections.EnumerableExtensions.WhereNotNull<T>(this System.Collec
 static Louis.Collections.EnumerableExtensions.WhereNotNull<T>(this System.Collections.Generic.IEnumerable<T?>! this) -> System.Collections.Generic.IEnumerable<T>!
 static Louis.Collections.EnumerableExtensions.WhereNotNullOrEmpty(this System.Collections.Generic.IEnumerable<string?>! this) -> System.Collections.Generic.IEnumerable<string!>!
 static Louis.Collections.EnumerableExtensions.WhereNotNullOrWhiteSpace(this System.Collections.Generic.IEnumerable<string?>! this) -> System.Collections.Generic.IEnumerable<string!>!
+static Louis.DateOnlyExtensions.GetEndOfMonth(this System.DateOnly this) -> System.DateOnly
+static Louis.DateOnlyExtensions.GetEndOfWeek(this System.DateOnly this) -> System.DateOnly
+static Louis.DateOnlyExtensions.GetEndOfWeek(this System.DateOnly this, System.DayOfWeek firstDayOfWeek) -> System.DateOnly
+static Louis.DateOnlyExtensions.GetEndOfWeek(this System.DateOnly this, System.Globalization.CultureInfo! culture) -> System.DateOnly
+static Louis.DateOnlyExtensions.GetEndOfWeek(this System.DateOnly this, System.Globalization.DateTimeFormatInfo! dateTimeFormat) -> System.DateOnly
+static Louis.DateOnlyExtensions.GetStartOfMonth(this System.DateOnly this) -> System.DateOnly
+static Louis.DateOnlyExtensions.GetStartOfWeek(this System.DateOnly this) -> System.DateOnly
+static Louis.DateOnlyExtensions.GetStartOfWeek(this System.DateOnly this, System.DayOfWeek firstDayOfWeek) -> System.DateOnly
+static Louis.DateOnlyExtensions.GetStartOfWeek(this System.DateOnly this, System.Globalization.CultureInfo! culture) -> System.DateOnly
+static Louis.DateOnlyExtensions.GetStartOfWeek(this System.DateOnly this, System.Globalization.DateTimeFormatInfo! dateTimeFormat) -> System.DateOnly
+static Louis.DateOnlyUtility.Today.get -> System.DateOnly
+static Louis.DateTimeExtensions.GetEndOfDay(this System.DateTime this) -> System.DateTime
+static Louis.DateTimeExtensions.GetEndOfMonth(this System.DateTime this) -> System.DateTime
+static Louis.DateTimeExtensions.GetEndOfWeek(this System.DateTime this) -> System.DateTime
+static Louis.DateTimeExtensions.GetEndOfWeek(this System.DateTime this, System.DayOfWeek firstDayOfWeek) -> System.DateTime
+static Louis.DateTimeExtensions.GetEndOfWeek(this System.DateTime this, System.Globalization.CultureInfo! culture) -> System.DateTime
+static Louis.DateTimeExtensions.GetEndOfWeek(this System.DateTime this, System.Globalization.DateTimeFormatInfo! dateTimeFormat) -> System.DateTime
+static Louis.DateTimeExtensions.GetLastDayOfMonth(this System.DateTime this) -> System.DateTime
+static Louis.DateTimeExtensions.GetLastDayOfWeek(this System.DateTime this) -> System.DateTime
+static Louis.DateTimeExtensions.GetLastDayOfWeek(this System.DateTime this, System.DayOfWeek firstDayOfWeek) -> System.DateTime
+static Louis.DateTimeExtensions.GetLastDayOfWeek(this System.DateTime this, System.Globalization.CultureInfo! culture) -> System.DateTime
+static Louis.DateTimeExtensions.GetLastDayOfWeek(this System.DateTime this, System.Globalization.DateTimeFormatInfo! dateTimeFormat) -> System.DateTime
+static Louis.DateTimeExtensions.GetStartOfMonth(this System.DateTime this) -> System.DateTime
+static Louis.DateTimeExtensions.GetStartOfWeek(this System.DateTime this) -> System.DateTime
+static Louis.DateTimeExtensions.GetStartOfWeek(this System.DateTime this, System.DayOfWeek firstDayOfWeek) -> System.DateTime
+static Louis.DateTimeExtensions.GetStartOfWeek(this System.DateTime this, System.Globalization.CultureInfo! culture) -> System.DateTime
+static Louis.DateTimeExtensions.GetStartOfWeek(this System.DateTime this, System.Globalization.DateTimeFormatInfo! dateTimeFormat) -> System.DateTime
+static Louis.DateUtility.GetDaysFromStartOfWeek(System.DayOfWeek today) -> int
+static Louis.DateUtility.GetDaysFromStartOfWeek(System.DayOfWeek today, System.DayOfWeek firstDayOfWeek) -> int
+static Louis.DateUtility.GetDaysFromStartOfWeek(System.DayOfWeek today, System.Globalization.CultureInfo! culture) -> int
+static Louis.DateUtility.GetDaysFromStartOfWeek(System.DayOfWeek today, System.Globalization.DateTimeFormatInfo! dateTimeFormat) -> int
 static Louis.Diagnostics.ExceptionExtensions.AnyCausingException(this System.Exception! this, System.Func<System.Exception!, bool>! predicate) -> bool
 static Louis.Diagnostics.ExceptionExtensions.GetCausingExceptions(this System.Exception! this) -> System.Collections.Generic.IEnumerable<System.Exception!>!
 static Louis.Diagnostics.ExceptionExtensions.IsCriticalError(this System.Exception! this) -> bool

--- a/src/Louis/TimeConstants.cs
+++ b/src/Louis/TimeConstants.cs
@@ -1,0 +1,115 @@
+﻿// Copyright (c) Tenacom and contributors. Licensed under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Louis;
+
+/// <summary>
+/// Provides constants for typical "magic numbers" used when working with times or time intervals.
+/// </summary>
+public static class TimeConstants
+{
+    /// <summary>
+    /// Gets the number of ticks in a millisecond.
+    /// </summary>
+    public const long TicksPerMillisecond = 10000L;
+
+    /// <summary>
+    /// Gets the number of milliseconds in a second.
+    /// </summary>
+    public const int MillisecondsPerSecond = 1000;
+
+    /// <summary>
+    /// Gets the number of seconds in a minute.
+    /// </summary>
+    public const int SecondsPerMinute = 60;
+
+    /// <summary>
+    /// Gets the number of minutes in an hour.
+    /// </summary>
+    public const int MinutesPerHour = 60;
+
+    /// <summary>
+    /// Gets the number of hours in a day.
+    /// </summary>
+    public const int HoursPerDay = 24;
+
+    /// <summary>
+    /// Gets the number of days in a week.
+    /// </summary>
+    public const int DaysPerWeek = 7;
+
+    /// <summary>
+    /// Gets the number of ticks in a second.
+    /// </summary>
+    public const long TicksPerSecond = TicksPerMillisecond * MillisecondsPerSecond;
+
+    /// <summary>
+    /// Gets the number of ticks in a minute.
+    /// </summary>
+    public const long TicksPerMinute = TicksPerSecond * SecondsPerMinute;
+
+    /// <summary>
+    /// Gets the number of ticks in an hour.
+    /// </summary>
+    public const long TicksPerHour = TicksPerMinute * MinutesPerHour;
+
+    /// <summary>
+    /// Gets the number of ticks in a day.
+    /// </summary>
+    public const long TicksPerDay = TicksPerHour * HoursPerDay;
+
+    /// <summary>
+    /// Gets the number of ticks in a week.
+    /// </summary>
+    public const long TicksPerWeek = TicksPerDay * DaysPerWeek;
+
+    /// <summary>
+    /// Gets the number of milliseconds in a minute.
+    /// </summary>
+    public const int MillisecondsPerMinute = MillisecondsPerSecond * SecondsPerMinute;
+
+    /// <summary>
+    /// Gets the number of milliseconds in an hour.
+    /// </summary>
+    public const int MillisecondsPerHour = MillisecondsPerMinute * MinutesPerHour;
+
+    /// <summary>
+    /// Gets the number of milliseconds in a day.
+    /// </summary>
+    public const int MillisecondsPerDay = MillisecondsPerHour * HoursPerDay;
+
+    /// <summary>
+    /// Gets the number of milliseconds in a week.
+    /// </summary>
+    public const int MillisecondsPerWeek = MillisecondsPerDay * DaysPerWeek;
+
+    /// <summary>
+    /// Gets the number of seconds in an hour.
+    /// </summary>
+    public const int SecondsPerHour = SecondsPerMinute * MinutesPerHour;
+
+    /// <summary>
+    /// Gets the number of seconds in a day.
+    /// </summary>
+    public const int SecondsPerDay = SecondsPerHour * HoursPerDay;
+
+    /// <summary>
+    /// Gets the number of seconds in a week.
+    /// </summary>
+    public const int SecondsPerWeek = SecondsPerDay * DaysPerWeek;
+
+    /// <summary>
+    /// Gets the number of minutes in a day.
+    /// </summary>
+    public const int MinutesPerDay = MinutesPerHour * HoursPerDay;
+
+    /// <summary>
+    /// Gets the number of minutes in a week.
+    /// </summary>
+    public const int MinutesPerWeek = MinutesPerDay * DaysPerWeek;
+
+    /// <summary>
+    /// Gets the number of hours in a week.
+    /// </summary>
+    public const int HoursPerWeek = HoursPerDay * DaysPerWeek;
+}


### PR DESCRIPTION
## Proposed changes

Add a series of date- and time-related utilities and extensions:

- constants for several "magic numbers" (ticks per hour, ticks per day, milliseconds per day, etc.);
- utility methods to get the first and last day in a week or month, either relative to the current date, or as extension methods on both `DateTime` and `DateOnly`;
- extension methods for `DateTime` to get the last day in a week or month, at the latest possible time (last tick), useful to define inclusive ranges (for example as parameters to a SQL query using a `BETWEEN` clause).

### Checklist of related issues / discussions

There was no time for opening an issue, let alone discussing it. The added code comes from production projects, where it has been copypasted more times than I'll ever admit. 😬

## Types of changes

This pull request introduces the following types of changes:

- [ ] Bug fix <!-- This includes changes to tests and XML documentation as applicable. -->
- [x] New feature <!-- This includes changes to tests and XML documentation as applicable. -->
- [ ] Test addition / update (no changes to non-test code)
- [ ] Refactor (no changes in public API syntax or semantics)
- [ ] Performance improvement (no changes in public API syntax or semantics)
- [ ] Documentation (`docs` directory) update
- [ ] Dependency addition / update
- [ ] Changes to the build scripts
- [ ] Changes to CI (workflows, bot / app configurations)
- [ ] Changes to repository files (`.gitattributes`, `.gitignore`)
- [ ] Other

### Breaking changes

This pull request introduces breaking changes:

- [ ] Yes
- [x] No

## Checklist

- **For all types of changes:**
  - [x] I have read the [Code of Conduct](https://github.com/Tenacom/.github/blob/main/CODE_OF_CONDUCT.md) and agree to be bound by it
  - [x] I have read the [Contributor Guide](https://github.com/Tenacom/.github/blob/main/CONTRIBUTING.md) and agree to follow it
- **For code changes only:**
  - [x] The project builds on my machine, via the provided build script, _with zero warnings_
  - [ ] I have added tests that prove my feature works / my fix is effective
  - [x] I have added / modified XML documentation according to changes in code
  - [ ] I have checked that all the links I added or modified in XML documentation point to their intended destination
- **For documentation changes (`docs` directory) only:**
  - [ ] I have built and tested documentation locally
  - [ ] I have checked that all the links I added or modified point to their intended destination
